### PR TITLE
docs: replace TODO labels on all high-level docstrings

### DIFF
--- a/docs/apidocs/povm_toolbox.library.metadata.rst
+++ b/docs/apidocs/povm_toolbox.library.metadata.rst
@@ -2,6 +2,9 @@
 Metadata
 ========
 
+.. warning::
+   This API reference is still `under construction`.
+
 .. _povm_toolbox-library-metadata:
 
 .. automodule:: povm_toolbox.library.metadata

--- a/docs/apidocs/povm_toolbox.library.rst
+++ b/docs/apidocs/povm_toolbox.library.rst
@@ -2,6 +2,9 @@
 Library
 =======
 
+.. warning::
+   This API reference is still `under construction`.
+
 .. _povm_toolbox-library:
 
 .. automodule:: povm_toolbox.library

--- a/docs/apidocs/povm_toolbox.post_processor.rst
+++ b/docs/apidocs/povm_toolbox.post_processor.rst
@@ -2,6 +2,9 @@
 Post Processor
 ==============
 
+.. warning::
+   This API reference is still `under construction`.
+
 .. _povm_toolbox-post_processor:
 
 .. automodule:: povm_toolbox.post_processor

--- a/docs/apidocs/povm_toolbox.quantum_info.rst
+++ b/docs/apidocs/povm_toolbox.quantum_info.rst
@@ -2,6 +2,9 @@
 Quantum Info
 ============
 
+.. warning::
+   This API reference is still `under construction`.
+
 .. _povm_toolbox-quantum_info:
 
 .. automodule:: povm_toolbox.quantum_info

--- a/docs/apidocs/povm_toolbox.rst
+++ b/docs/apidocs/povm_toolbox.rst
@@ -2,6 +2,9 @@
 POVM Toolbox
 ============
 
+.. warning::
+   This API reference is still `under construction`.
+
 .. _povm_toolbox:
 
 .. automodule:: povm_toolbox

--- a/docs/apidocs/povm_toolbox.sampler.rst
+++ b/docs/apidocs/povm_toolbox.sampler.rst
@@ -2,6 +2,9 @@
 Sampler
 =======
 
+.. warning::
+   This API reference is still `under construction`.
+
 .. _povm_toolbox-sampler:
 
 .. automodule:: povm_toolbox.sampler

--- a/docs/apidocs/povm_toolbox.utilities.rst
+++ b/docs/apidocs/povm_toolbox.utilities.rst
@@ -2,6 +2,9 @@
 Utilities
 =========
 
+.. warning::
+   This API reference is still `under construction`.
+
 .. _povm_toolbox-utilities:
 
 .. automodule:: povm_toolbox.utilities

--- a/povm_toolbox/__init__.py
+++ b/povm_toolbox/__init__.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO.
+"""A toolbox for the implementation of positive operator-valued measures (POVMs).
 
 .. currentmodule:: povm_toolbox
 

--- a/povm_toolbox/library/__init__.py
+++ b/povm_toolbox/library/__init__.py
@@ -8,7 +8,11 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO.
+"""A library of POVM implementations.
+
+This module provides "ready-to-go" POVM implementations.
+Each one serves as a factory to generate a specific, concrete POVM and provides the means to
+`sample` from it.
 
 .. currentmodule:: povm_toolbox.library
 

--- a/povm_toolbox/library/classical_shadows.py
+++ b/povm_toolbox/library/classical_shadows.py
@@ -18,7 +18,7 @@ from .locally_biased_classical_shadows import LocallyBiasedClassicalShadows
 
 
 class ClassicalShadows(LocallyBiasedClassicalShadows):
-    """TODO."""
+    """A classical shadows POVM."""
 
     def __init__(
         self,

--- a/povm_toolbox/library/locally_biased_classical_shadows.py
+++ b/povm_toolbox/library/locally_biased_classical_shadows.py
@@ -18,7 +18,7 @@ from .randomized_projective_measurements import RandomizedProjectiveMeasurements
 
 
 class LocallyBiasedClassicalShadows(RandomizedProjectiveMeasurements):
-    """TODO."""
+    """A locally-biased classical shadows POVM."""
 
     def __init__(
         self,

--- a/povm_toolbox/library/metadata/__init__.py
+++ b/povm_toolbox/library/metadata/__init__.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO.
+"""Metadata containers for your POVM sampling results.
 
 .. currentmodule:: povm_toolbox.library.metadata
 

--- a/povm_toolbox/library/metadata/povm_metadata.py
+++ b/povm_toolbox/library/metadata/povm_metadata.py
@@ -19,6 +19,7 @@ from ..povm_implementation import POVMImplementation
 
 @dataclass
 class POVMMetadata:
-    """TODO."""
+    """The bare metadata container for POVM sampling results."""
 
     povm_implementation: POVMImplementation
+    """The POVM implementation which produced the results to which this metadata belongs."""

--- a/povm_toolbox/library/metadata/rpm_metadata.py
+++ b/povm_toolbox/library/metadata/rpm_metadata.py
@@ -22,10 +22,12 @@ from .povm_metadata import POVMMetadata
 
 @dataclass(repr=False)
 class RPMMetadata(POVMMetadata):
-    """TODO."""
+    """A metadata container for randomized projective measurements (RPM) POVM sampling results."""
 
     pvm_keys: np.ndarray
-    """Shape of `pvm_keys` is assumed to be ``(*pv.shape, num_batches, n_qubit)``,
+    """The keys which associate a specific result sample with the corresponding RPM parameters.
+
+    Shape of `pvm_keys` is assumed to be ``(*pv.shape, num_batches, n_qubit)``,
     where ``pv`` is the bindings array provided by the user to run with the
     parametrized quantum circuit supplied in the :meth:`.POVMSampler.run` method.
     """

--- a/povm_toolbox/library/povm_implementation.py
+++ b/povm_toolbox/library/povm_implementation.py
@@ -33,7 +33,7 @@ MetadataT = TypeVar("MetadataT", bound="POVMMetadata")
 
 
 class POVMImplementation(ABC, Generic[MetadataT]):
-    """Abstract base class that contains all methods that any specific POVMImplementation subclass should implement."""
+    """The abstract base interface for all POVM implementations in this library."""
 
     classical_register_name = "povm_measurement_creg"
 

--- a/povm_toolbox/library/randomized_projective_measurements.py
+++ b/povm_toolbox/library/randomized_projective_measurements.py
@@ -30,7 +30,7 @@ from .povm_implementation import POVMImplementation
 
 
 class RandomizedProjectiveMeasurements(POVMImplementation[RPMMetadata]):
-    """Class to represent the implementation of randomized projective measurements."""
+    """A general randomized projective measurements POVM."""
 
     def __init__(
         self,

--- a/povm_toolbox/post_processor/__init__.py
+++ b/povm_toolbox/post_processor/__init__.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO.
+"""A module of POVM result post-processing tools.
 
 .. currentmodule:: povm_toolbox.post_processor
 

--- a/povm_toolbox/post_processor/povm_post_processor.py
+++ b/povm_toolbox/post_processor/povm_post_processor.py
@@ -19,7 +19,7 @@ from povm_toolbox.sampler import POVMPubResult
 
 
 class POVMPostprocessor:
-    """Class to represent a POVM post-processor.."""
+    """A common POVM result post-processor."""
 
     def __init__(
         self,

--- a/povm_toolbox/quantum_info/__init__.py
+++ b/povm_toolbox/quantum_info/__init__.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO.
+"""A module for working with POVMs on a quantum-informational setting.
 
 .. currentmodule:: povm_toolbox.quantum_info
 

--- a/povm_toolbox/sampler/__init__.py
+++ b/povm_toolbox/sampler/__init__.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO.
+"""A module of sampling tools for POVMs.
 
 .. currentmodule:: povm_toolbox.sampler
 

--- a/povm_toolbox/sampler/povm_sampler.py
+++ b/povm_toolbox/sampler/povm_sampler.py
@@ -26,7 +26,7 @@ from .povm_sampler_pub import POVMSamplerPub, POVMSamplerPubLike
 
 
 class POVMSampler:
-    """POVM Sampler V2 class."""
+    """A :class:`.BaseSamplerV2`-compatible interface for sampling POVMs."""
 
     def __init__(
         self,

--- a/povm_toolbox/sampler/povm_sampler_job.py
+++ b/povm_toolbox/sampler/povm_sampler_job.py
@@ -23,7 +23,7 @@ from .povm_sampler_result import POVMPubResult
 
 
 class POVMSamplerJob(BasePrimitiveJob[POVMPubResult, JobStatus]):
-    """Job class for the :class:`POVMSampler`."""
+    """Job class for the :class:`.POVMSampler`."""
 
     def __init__(
         self,

--- a/povm_toolbox/sampler/povm_sampler_pub.py
+++ b/povm_toolbox/sampler/povm_sampler_pub.py
@@ -38,7 +38,7 @@ POVMSamplerPubLike = Union[
 
 
 class POVMSamplerPub(ShapedMixin):
-    """Pub (Primitive Unified Bloc) for a POVM Sampler.
+    """Pub (Primitive Unified Bloc) for the :class:`.POVMSampler`.
 
     Pub is composed of tuple (circuit, parameter_values, shots, povm_implementation).
     """

--- a/povm_toolbox/sampler/povm_sampler_result.py
+++ b/povm_toolbox/sampler/povm_sampler_result.py
@@ -21,7 +21,7 @@ from povm_toolbox.library.metadata import POVMMetadata
 
 
 class POVMPubResult(PubResult):
-    """Base class to gather all relevant result information."""
+    """Result class for the :class:`.POVMSamplerJob`."""
 
     def __init__(
         self,

--- a/povm_toolbox/utilities.py
+++ b/povm_toolbox/utilities.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO.
+"""A collection of common utilities.
 
 .. currentmodule:: povm_toolbox.utilities
 


### PR DESCRIPTION
This ensures that all "high-level" docstrings have at least a short description.
This is important because these are the single lines that are pulled into the preview on each listing of submodules and/or classes in the `autosummary` statements.

I also added an "under construction"-disclaimer to all API reference module pages.