### PR TITLE
Expose RNG in `RandomizedProjectiveMeasurements` and its subclasses

### DIFF
--- a/povm_toolbox/library/classical_shadows.py
+++ b/povm_toolbox/library/classical_shadows.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import numpy as np
+from numpy.random import Generator
 
 from .locally_biased_classical_shadows import LocallyBiasedClassicalShadows
 
@@ -24,6 +25,7 @@ class ClassicalShadows(LocallyBiasedClassicalShadows):
         self,
         n_qubit: int,
         shot_batch_size: int = 1,
+        seed_rng: int | Generator | None = None,
     ):
         """Construct a classical shadow POVM.
 
@@ -34,4 +36,5 @@ class ClassicalShadows(LocallyBiasedClassicalShadows):
             n_qubit=n_qubit,
             bias=bias,
             shot_batch_size=shot_batch_size,
+            seed_rng=seed_rng,
         )

--- a/povm_toolbox/library/classical_shadows.py
+++ b/povm_toolbox/library/classical_shadows.py
@@ -27,9 +27,19 @@ class ClassicalShadows(LocallyBiasedClassicalShadows):
         shot_batch_size: int = 1,
         seed_rng: int | Generator | None = None,
     ):
-        """Construct a classical shadow POVM.
+        """Implement a classical shadows POVM.
 
-        TODO: The same as above, but also hard-coding the biases to be equally distributed.
+        This is a special case of a :class:`LocallyBiasedClassicalShadows`, where
+        the bias are taken to be uniform. That is, there is an equal probability
+        to perform a measurement in the Z, X and Y bases.
+
+        Args:
+            n_qubits: the number of qubits.
+            shot_batch_size: number of shots assigned to each sampled measurement basis.
+                If set to 1, a new basis is sampled for each shot.
+            seed_rng: optional seed to fix the :class:`numpy.random.Generator` used to
+                sample measurement bases. The user can also directly provide a random
+                generator. If None, a random seed will be used.
         """
         bias = 1.0 / 3.0 * np.ones(3)
         super().__init__(

--- a/povm_toolbox/library/locally_biased_classical_shadows.py
+++ b/povm_toolbox/library/locally_biased_classical_shadows.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import numpy as np
+from numpy.random import Generator
 
 from .randomized_projective_measurements import RandomizedProjectiveMeasurements
 
@@ -25,6 +26,7 @@ class LocallyBiasedClassicalShadows(RandomizedProjectiveMeasurements):
         n_qubit: int,
         bias: np.ndarray,
         shot_batch_size: int = 1,
+        seed_rng: int | Generator | None = None,
     ):
         """Construct a locally-biased classical shadow POVM.
 
@@ -37,4 +39,5 @@ class LocallyBiasedClassicalShadows(RandomizedProjectiveMeasurements):
             bias=bias,
             angles=angles,
             shot_batch_size=shot_batch_size,
+            seed_rng=seed_rng,
         )

--- a/povm_toolbox/library/locally_biased_classical_shadows.py
+++ b/povm_toolbox/library/locally_biased_classical_shadows.py
@@ -28,9 +28,23 @@ class LocallyBiasedClassicalShadows(RandomizedProjectiveMeasurements):
         shot_batch_size: int = 1,
         seed_rng: int | Generator | None = None,
     ):
-        """Construct a locally-biased classical shadow POVM.
+        """Implement a locally-biased classical shadow POVM.
 
-        TODO: The same as above, but the angles are hard-coded to be X/Y/Z for all qubits.
+        This is a special case of a :class:`RandomizedProjectiveMeasurements`, where the PVMs are
+        chosen to be Z-, X- and Y-measurements.
+
+        Args:
+            n_qubits: the number of qubits.
+            bias: can be either 1D or 2D. If 1D, it should contain float values indicating the bias
+                for measuring in each of the PVMs. I.e., its length equals the number of PVMs (3).
+                These floats should sum to 1. If 2D, it will have a new set of biases for each
+                qubit.
+            shot_batch_size: number of shots assigned to each sampled PVM. If set to 1, a new PVM
+                is sampled for each shot.
+            seed_rng: optional seed to fix the :class:`numpy.random.Generator` used to sample PVMs.
+                The Z-,X-,Y-measurements are sampled according to the probability distribution(s)
+                specified by ``bias``. The user can also directly provide a random generator. If
+                None, a random seed will be used.
         """
         angles = np.array([0.0, 0.0, 0.5 * np.pi, 0.0, 0.5 * np.pi, 0.5 * np.pi])
         assert bias.shape[-1] == 3

--- a/povm_toolbox/library/randomized_projective_measurements.py
+++ b/povm_toolbox/library/randomized_projective_measurements.py
@@ -58,21 +58,36 @@ class RandomizedProjectiveMeasurements(POVMImplementation[RPMMetadata]):
                 for each qubit.
             shot_batch_size: number of shots assigned to each sampled PVM. If set to 1, a new PVM
                 is sampled for each shot.
+            seed_rng: optional seed to fix the :class:`numpy.random.Generator` used to sample PVMs.
+                The PVMs are sampled according to the probability distribution(s) specified by
+                ``bias``. The user can also directly provide a random generator. If None, a random
+                seed will be used.
 
         Raises:
-            ValueError: TODO.
+            ValueError: If the shape of ``bias`` is not compatible with the shape of ``angles``.
+            ValueError: If the shape of ``bias`` is not compatible with ``n_qubit``.
+            ValueError: If there is a negative value in the probability distribution(s) specified
+                by ``bias``.
+            ValueError: If the probability distribution(s) specified by ``bias`` don't sum up to 1.
+            ValueError: If the shape of ``angles`` is not compatible with ``n_qubit``.
             TypeError: If the type of ``seed_rng`` is not valid.
         """
         super().__init__(n_qubit)
 
         if 2 * bias.shape[-1] != angles.shape[-1]:
-            raise ValueError(f"TODO: error message. {bias.shape[-1]}, {angles.shape[-1]}.")
+            raise ValueError(
+                f"The shape of ``bias`` ({bias.shape}) is not compatible with the shape"
+                f" of ``angles`` ({angles.shape})."
+            )
         self._n_PVMs = bias.shape[-1]
 
         if bias.ndim == 1:
             bias = np.tile(bias, (self.n_qubit, 1))
         elif (bias.ndim == 2 and bias.shape[0] != self.n_qubit) or bias.ndim > 2:
-            raise ValueError("TODO: error message.")
+            raise ValueError(
+                f"The shape of ``bias`` ({bias.shape}) is not compatible with"
+                f" ``n_qubit`` ({n_qubit})."
+            )
         if np.any(bias < 0.0):
             raise ValueError(
                 "There should not be any negative values in the probability distribution parameters."
@@ -84,7 +99,10 @@ class RandomizedProjectiveMeasurements(POVMImplementation[RPMMetadata]):
         if angles.ndim == 1:
             angles = np.tile(angles, (self.n_qubit, 1))
         elif (angles.ndim == 2 and angles.shape[0] != self.n_qubit) or angles.ndim > 2:
-            raise ValueError("TODO: error message.")
+            raise ValueError(
+                f"The shape of ``angles`` ({angles.shape}) is not compatible with"
+                f" ``n_qubit`` ({n_qubit})."
+            )
         self.angles = angles.reshape((self.n_qubit, self._n_PVMs, 2))
 
         self.msmt_qc = self._build_qc()

--- a/povm_toolbox/library/randomized_projective_measurements.py
+++ b/povm_toolbox/library/randomized_projective_measurements.py
@@ -61,7 +61,7 @@ class RandomizedProjectiveMeasurements(POVMImplementation[RPMMetadata]):
 
         Raises:
             ValueError: TODO.
-            TypeError: TODO.
+            TypeError: If the type of ``seed_rng`` is not valid.
         """
         super().__init__(n_qubit)
 


### PR DESCRIPTION
This RNG is used to sample the different (random) projetcive measurements, effectively generating the overall _randomized_ measurement.

Closes #5 