### PR TITLE
``shots`` and ``shot_batch_size`` interpretation

### DIFF
--- a/povm_toolbox/library/classical_shadows.py
+++ b/povm_toolbox/library/classical_shadows.py
@@ -46,8 +46,11 @@ class ClassicalShadows(LocallyBiasedClassicalShadows):
                 to the :meth:`.compose_circuits` has been transpiled, its final
                 transpile layout will be used as default value, 2) otherwise, a
                 simple one-to-one layout ``list(range(n_qubits))`` is used.
-            shot_batch_size: number of shots assigned to each sampled measurement basis.
-                If set to 1, a new basis is sampled for each shot.
+            shot_batch_size: number of shots assigned to each sampled PVM. If set
+                to 1, a new PVM is sampled for each shot. Note that the ``shots``
+                argument of the method :meth:`.POVMSampler.run` is effectively the
+                number of batches (i.e., the number of sampled PVMs). The actual
+                total number of shots is then ``shots``  multiplied by ``shot_batch_size``.
             seed_rng: optional seed to fix the :class:`numpy.random.Generator` used to
                 sample measurement bases. The user can also directly provide a random
                 generator. If None, a random seed will be used.

--- a/povm_toolbox/library/classical_shadows.py
+++ b/povm_toolbox/library/classical_shadows.py
@@ -26,7 +26,7 @@ class ClassicalShadows(LocallyBiasedClassicalShadows):
         n_qubit: int,
         measurement_twirl: bool = False,
         measurement_layout: list[int] | None = None,  # TODO: add | Layout
-        shot_batch_size: int = 1,
+        shot_repetitions: int = 1,
         seed_rng: int | Generator | None = None,
     ):
         """Implement a classical shadows POVM.
@@ -46,11 +46,13 @@ class ClassicalShadows(LocallyBiasedClassicalShadows):
                 to the :meth:`.compose_circuits` has been transpiled, its final
                 transpile layout will be used as default value, 2) otherwise, a
                 simple one-to-one layout ``list(range(n_qubits))`` is used.
-            shot_batch_size: number of shots assigned to each sampled PVM. If set
-                to 1, a new PVM is sampled for each shot. Note that the ``shots``
-                argument of the method :meth:`.POVMSampler.run` is effectively the
-                number of batches (i.e., the number of sampled PVMs). The actual
-                total number of shots is then ``shots``  multiplied by ``shot_batch_size``.
+            shot_repetitions: number of times the measurement is repeated for each
+                sampled PVM. More precisely, a new PVM is sampled for all ``shots``
+                (i.e. the number of times as specified by the user via the ``shots``
+                argument of the method :meth:`.POVMSampler.run`). Then, the parameter
+                ``shot_repetitions`` states how many times we repeat the measurement
+                for each sampled PVM (default is 1). Therefore, the effective total
+                number of measurement shots is ``shots`` multiplied by ``shot_repetitions``.
             seed_rng: optional seed to fix the :class:`numpy.random.Generator` used to
                 sample measurement bases. The user can also directly provide a random
                 generator. If None, a random seed will be used.
@@ -61,6 +63,6 @@ class ClassicalShadows(LocallyBiasedClassicalShadows):
             bias=bias,
             measurement_twirl=measurement_twirl,
             measurement_layout=measurement_layout,
-            shot_batch_size=shot_batch_size,
+            shot_repetitions=shot_repetitions,
             seed_rng=seed_rng,
         )

--- a/povm_toolbox/library/locally_biased_classical_shadows.py
+++ b/povm_toolbox/library/locally_biased_classical_shadows.py
@@ -50,8 +50,11 @@ class LocallyBiasedClassicalShadows(RandomizedProjectiveMeasurements):
                 to the :meth:`.compose_circuits` has been transpiled, its final
                 transpile layout will be used as default value, 2) otherwise, a
                 simple one-to-one layout ``list(range(n_qubits))`` is used.
-            shot_batch_size: number of shots assigned to each sampled PVM. If set to 1, a new PVM
-                is sampled for each shot.
+            shot_batch_size: number of shots assigned to each sampled PVM. If set
+                to 1, a new PVM is sampled for each shot. Note that the ``shots``
+                argument of the method :meth:`.POVMSampler.run` is effectively the
+                number of batches (i.e., the number of sampled PVMs). The actual
+                total number of shots is then ``shots``  multiplied by ``shot_batch_size``.
             seed_rng: optional seed to fix the :class:`numpy.random.Generator` used to sample PVMs.
                 The Z-,X-,Y-measurements are sampled according to the probability distribution(s)
                 specified by ``bias``. The user can also directly provide a random generator. If

--- a/povm_toolbox/library/locally_biased_classical_shadows.py
+++ b/povm_toolbox/library/locally_biased_classical_shadows.py
@@ -27,7 +27,7 @@ class LocallyBiasedClassicalShadows(RandomizedProjectiveMeasurements):
         bias: np.ndarray,
         measurement_twirl: bool = False,
         measurement_layout: list[int] | None = None,  # TODO: add | Layout
-        shot_batch_size: int = 1,
+        shot_repetitions: int = 1,
         seed_rng: int | Generator | None = None,
     ):
         """Implement a locally-biased classical shadow POVM.
@@ -50,11 +50,13 @@ class LocallyBiasedClassicalShadows(RandomizedProjectiveMeasurements):
                 to the :meth:`.compose_circuits` has been transpiled, its final
                 transpile layout will be used as default value, 2) otherwise, a
                 simple one-to-one layout ``list(range(n_qubits))`` is used.
-            shot_batch_size: number of shots assigned to each sampled PVM. If set
-                to 1, a new PVM is sampled for each shot. Note that the ``shots``
-                argument of the method :meth:`.POVMSampler.run` is effectively the
-                number of batches (i.e., the number of sampled PVMs). The actual
-                total number of shots is then ``shots``  multiplied by ``shot_batch_size``.
+            shot_repetitions: number of times the measurement is repeated for each
+                sampled PVM. More precisely, a new PVM is sampled for all ``shots``
+                (i.e. the number of times as specified by the user via the ``shots``
+                argument of the method :meth:`.POVMSampler.run`). Then, the parameter
+                ``shot_repetitions`` states how many times we repeat the measurement
+                for each sampled PVM (default is 1). Therefore, the effective total
+                number of measurement shots is ``shots`` multiplied by ``shot_repetitions``.
             seed_rng: optional seed to fix the :class:`numpy.random.Generator` used to sample PVMs.
                 The Z-,X-,Y-measurements are sampled according to the probability distribution(s)
                 specified by ``bias``. The user can also directly provide a random generator. If
@@ -68,6 +70,6 @@ class LocallyBiasedClassicalShadows(RandomizedProjectiveMeasurements):
             angles=angles,
             measurement_twirl=measurement_twirl,
             measurement_layout=measurement_layout,
-            shot_batch_size=shot_batch_size,
+            shot_repetitions=shot_repetitions,
             seed_rng=seed_rng,
         )

--- a/povm_toolbox/library/randomized_projective_measurements.py
+++ b/povm_toolbox/library/randomized_projective_measurements.py
@@ -205,9 +205,10 @@ class RandomizedProjectiveMeasurements(POVMImplementation[RPMMetadata]):
             circuit: A quantum circuit.
             circuit_binding: A bindings array.
             shots: A specific number of shots to run with. Note that ``shots`` is
-                effectively the number of measurement batches (i.e., the number
-                of sampled PVMs). The actual total number of shots is then
-                ``shots``  multiplied by ``self.shot_repetitions``.
+                effectively the number of times we sample PVMs. Then, for each
+                sampled PVM, the measurement is repeated ``self.shot_repetitions``
+                times. Therefore, the actual total number of measurement shots is
+                then ``shots`` multiplied by ``self.shot_repetitions``.
             pass_manager: An optional pass manager. After the supplied circuit has
                 been composed with the measurement circuit, the pass manager will
                 transpile the composed circuit.

--- a/test/library/test_randomized_projective_measurements.py
+++ b/test/library/test_randomized_projective_measurements.py
@@ -90,7 +90,7 @@ class TestRandomizedPMs(TestCase):
         exp_value, _ = post_processor.get_single_exp_value_and_std(observable)
         self.assertAlmostEqual(exp_value, 1.1718749999999998)
 
-    def test_batch_size(self):
+    def test_shot_repetitions(self):
         """Test if the twirling option works correctly."""
         rng = default_rng(65)
 
@@ -98,7 +98,7 @@ class TestRandomizedPMs(TestCase):
         qc.h(0)
 
         n_qubit = qc.num_qubits
-        measurement = ClassicalShadows(n_qubit, seed_rng=rng, shot_batch_size=7)
+        measurement = ClassicalShadows(n_qubit, seed_rng=rng, shot_repetitions=7)
 
         rng2 = default_rng(56)
 


### PR DESCRIPTION
As discussed in #4, we choose to interpret ``shot_batch_size`` as a multiplier of the number of shots. That is, effectively, ``shots`` is the number of measurement batches and the actual number of shots performed is ``shots * shot_batch_size``.

Closes #4.