### PR TITLE
fix: a quick-fix for dealing with larger qubit counts

### DIFF
--- a/povm_toolbox/quantum_info/base_frame.py
+++ b/povm_toolbox/quantum_info/base_frame.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import math
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 
@@ -53,7 +54,7 @@ class BaseFrame(ABC, Generic[LabelT]):
 
         For qubits, this is always :math:`\log_2(`:attr:`.dimension`:math:`)`.
         """
-        return int(np.log2(self.dimension))
+        return int(math.log2(self.dimension))
 
     @property
     @abstractmethod

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import math
 import sys
 import warnings
 from collections.abc import Sequence
@@ -297,7 +298,7 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
         # Assert matching operator and POVM sizes.
         if hermitian_op.num_qubits != self.n_subsystems:
             raise ValueError(
-                f"Size of the operator ({hermitian_op.num_qubits}) does not match the size of the povm ({np.log2(self.dimension)})."
+                f"Size of the operator ({hermitian_op.num_qubits}) does not match the size of the povm ({math.log2(self.dimension)})."
             )
 
         # If frame_op_idx is ``None``, it means all outcomes are queried


### PR DESCRIPTION
When dealing with qubit numbers > 63, `np.log2` fails because the integer cannot be converted to a proper C type and, thus, gets passed into numpy as an object-array.
`math.log` is a Python function which can handle the unbounded Python integer sizes just fine.

This is more of an ad-hoc fix to the current state of the code. A different approach would be to consider actually storing `n_subsystems` rather than always computing it on the fly. I will open a separate issue for that.