### PR TITLE
[docs] differentiate between native and inherited methods

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -13,19 +13,34 @@
    :show-inheritance:
 
 {% block attributes_summary %}
-  {% if attributes %}
+  {% set wanted_attributes = (attributes | reject('in', inherited_members) | list) %}
+  {% if wanted_attributes %}
    .. rubric:: Attributes
-    {% for item in attributes %}
+    {% for item in wanted_attributes %}
+   .. autoattribute:: {{ item }}
+    {%- endfor %}
+  {% endif %}
+  {% set inherited_attributes = (attributes | select('in', inherited_members) | list) %}
+  {% if inherited_attributes %}
+   .. rubric:: Inherited Attributes
+    {% for item in inherited_attributes %}
    .. autoattribute:: {{ item }}
     {%- endfor %}
   {% endif %}
 {% endblock -%}
 
 {% block methods_summary %}
-  {% set wanted_methods = (methods | reject('==', '__init__') | list) %}
+  {% set wanted_methods = (methods | reject('==', '__init__') | reject('in', inherited_members) | list) %}
   {% if wanted_methods %}
    .. rubric:: Methods
     {% for item in wanted_methods %}
+   .. automethod:: {{ item }}
+    {%- endfor %}
+  {% endif %}
+  {% set inherited_methods = (methods | reject('==', '__init__') | select('in', inherited_members) | list) %}
+  {% if inherited_methods %}
+   .. rubric:: Inherited Methods
+    {% for item in inherited_methods %}
    .. automethod:: {{ item }}
     {%- endfor %}
   {% endif %}


### PR DESCRIPTION
This updates the jinja template for the documentation pages of classes by separating native and inherited attributes and members into separate sections. Below is an example of what this does to the `SingleQubitPOVM` page:
![screenshot_1719578069](https://github.com/qiskit-community/povm-toolbox/assets/21973473/d38a3feb-e804-4744-874e-647b658df493)