### PR TITLE
Cleans up the documentation of the `quantum_info` submodule

### DIFF
--- a/povm_toolbox/library/metadata/povm_metadata.py
+++ b/povm_toolbox/library/metadata/povm_metadata.py
@@ -36,7 +36,7 @@ class POVMMetadata:
     circuit that is eventually sent to the internal :class:`.BaseSamplerV2`.
     """
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Implement the default ``__repr__`` method to avoid printing large objects.
 
         E.g., the attribute ``composed_circuit`` is a quantum circuit. With the default

--- a/povm_toolbox/quantum_info/__init__.py
+++ b/povm_toolbox/quantum_info/__init__.py
@@ -10,6 +10,10 @@
 
 """A module for working with POVMs on a quantum-informational setting.
 
+.. note::
+   In this module, we use the formalism of frame theory. POVMs are considered special cases
+   of *frames* and, for this reason, the *effects* of POVMs are often called *frame operators*.
+
 .. currentmodule:: povm_toolbox.quantum_info
 
 POVM Classes

--- a/povm_toolbox/quantum_info/base/base_dual.py
+++ b/povm_toolbox/quantum_info/base/base_dual.py
@@ -55,7 +55,7 @@ class BaseDual(BaseFrame[LabelT], ABC):
 
         Args:
             observable: the observable for which to compute the decomposition weights.
-            outcome_idx: TODO.
+            outcome_idx: label(s) indicating which decomposition weights are queried.
 
         Returns:
             TODO explain the different output types and how these represent the decomposition

--- a/povm_toolbox/quantum_info/base/base_dual.py
+++ b/povm_toolbox/quantum_info/base/base_dual.py
@@ -29,7 +29,6 @@ class BaseDual(BaseFrame[LabelT], ABC):
         """The number of outcomes of the Dual."""
         return self.num_operators
 
-    @abstractmethod
     def get_omegas(
         self,
         observable: SparsePauliOp | Operator,
@@ -51,18 +50,22 @@ class BaseDual(BaseFrame[LabelT], ABC):
         where :math:`D_k` make of this dual frame (i.e. ``self``).
 
         .. note::
-           TODO: explain how this relates to the :meth:`.BaseFrame.analysis` method.
+            In the frame theory formalism, the mapping
+            :math:`A: \mathcal{O} \mapsto \{\text{Tr}\left[\mathcal{O} D_k\right]\}_k`
+            is referred to as the *analysis operator*, which is implemented by
+            the :meth:`.analysis` method.
 
         Args:
             observable: the observable for which to compute the decomposition weights.
-            outcome_idx: label(s) indicating which decomposition weights are queried.
+            outcome_idx: label or set of labels indicating which decomposition weights
+                are queried. If ``None``, all weights are queried.
 
         Returns:
-            TODO explain the different output types and how these represent the decomposition
-            weights of the provided observable.
+            Decomposition weight(s) associated to the effect(s) specified by ``outcome_idx``.
+            If a specific outcome was queried, a ``float`` is returned. If a specific set of outcomes was
+            queried, a dictionary mapping outcome labels to weights is returned. If all outcomes were
+            queried, an array with all weights is returned.
         """
-        # TODO: why is this method labeled abstract but still has an implementation? One of these
-        # should be removed.
         return self.analysis(observable, outcome_idx)
 
     @abstractmethod

--- a/povm_toolbox/quantum_info/base/base_dual.py
+++ b/povm_toolbox/quantum_info/base/base_dual.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO."""
+"""BaseDual."""
 
 from __future__ import annotations
 
@@ -22,11 +22,11 @@ from .base_frame import BaseFrame, LabelT
 
 
 class BaseDual(BaseFrame[LabelT], ABC):
-    """Abstract base class that contains all methods that any specific Dual subclass should implement."""
+    """Abstract base class that contains all methods that any specific Dual should implement."""
 
     @property
     def num_outcomes(self) -> int:
-        """Give the number of outcomes of the Dual."""
+        """The number of outcomes of the Dual."""
         return self.num_operators
 
     @abstractmethod
@@ -35,23 +35,57 @@ class BaseDual(BaseFrame[LabelT], ABC):
         observable: SparsePauliOp | Operator,
         outcome_idx: LabelT | set[LabelT] | None = None,
     ) -> float | dict[LabelT, float] | np.ndarray:
-        """Return the decomposition weights of the provided observable into the POVM effects to which ``self`` is a dual."""
+        r"""Return the decomposition weights of the provided observable.
+
+        Computes the $\omega_k$ in
+
+        .. math::
+           \mathcal{O} = \sum_{k=1}^n \omega_k M_k
+
+        where $\mathcal{O}$ is the ``observable`` and $M_k$ are the effects of the POVM of which ``self`` is
+        the dual. The closed form for computing $\omega_k$ is
+
+        .. math::
+           \omega_k = \text{Tr}\left[\mathcal{O} D_k\right]
+
+        where $D_k$ make of this dual frame (i.e. ``self``).
+
+        .. note::
+           TODO: explain how this relates to the :meth:`.BaseFrame.analysis` method.
+
+        Args:
+            observable: the observable for which to compute the decomposition weights.
+            outcome_idx: TODO.
+
+        Returns:
+            TODO explain the different output types and how these represent the decomposition
+            weights of the provided observable.
+        """
+        # TODO: why is this method labeled abstract but still has an implementation? One of these
+        # should be removed.
         return self.analysis(observable, outcome_idx)
 
     @abstractmethod
     def is_dual_to(self, frame: BaseFrame) -> bool:
-        """Check if `self` is a dual to another frame."""
+        """Check if ``self`` is a dual to another frame.
+
+        Args:
+            frame: the other frame to check duality against.
+
+        Returns:
+            Whether ``self`` is dual to ``frame``.
+        """
 
     @classmethod
     @abstractmethod
     def build_dual_from_frame(cls, frame: BaseFrame, alphas: tuple[Any] | None = None) -> BaseDual:
-        """Construct a dual frame to another frame.
+        """Construct a dual frame to another (primal) frame.
 
         Args:
             frame: The primal frame from which we will build the dual frame.
-            alphas: parameters of the frame super-operator used to build the
-                dual frame. If None, the parameters are set as the traces of
-                each operator in the primal frame.
+            alphas: parameters of the frame super-operator used to build the dual frame.
+                If ``None``, the parameters are set as the traces of each operator in the primal
+                frame.
 
         Returns:
             A dual frame to the supplied ``frame``.

--- a/povm_toolbox/quantum_info/base/base_dual.py
+++ b/povm_toolbox/quantum_info/base/base_dual.py
@@ -61,10 +61,10 @@ class BaseDual(BaseFrame[LabelT], ABC):
                 are queried. If ``None``, all weights are queried.
 
         Returns:
-            Decomposition weight(s) associated to the effect(s) specified by ``outcome_idx``.
-            If a specific outcome was queried, a ``float`` is returned. If a specific set of outcomes was
-            queried, a dictionary mapping outcome labels to weights is returned. If all outcomes were
-            queried, an array with all weights is returned.
+            Decomposition weight(s) associated to the effect(s) specified by ``outcome_idx``. If a
+            specific outcome was queried, a ``float`` is returned. If a specific set of outcomes was
+            queried, a dictionary mapping outcome labels to weights is returned. If all outcomes
+            were queried, an array with all weights is returned.
         """
         return self.analysis(observable, outcome_idx)
 

--- a/povm_toolbox/quantum_info/base/base_dual.py
+++ b/povm_toolbox/quantum_info/base/base_dual.py
@@ -37,18 +37,18 @@ class BaseDual(BaseFrame[LabelT], ABC):
     ) -> float | dict[LabelT, float] | np.ndarray:
         r"""Return the decomposition weights of the provided observable.
 
-        Computes the $\omega_k$ in
+        Computes the :math:`\omega_k` in
 
         .. math::
            \mathcal{O} = \sum_{k=1}^n \omega_k M_k
 
-        where $\mathcal{O}$ is the ``observable`` and $M_k$ are the effects of the POVM of which ``self`` is
-        the dual. The closed form for computing $\omega_k$ is
+        where :math:`\mathcal{O}` is the ``observable`` and :math:`M_k` are the effects of the POVM
+        of which ``self`` is the dual. The closed form for computing :math:`\omega_k` is
 
         .. math::
            \omega_k = \text{Tr}\left[\mathcal{O} D_k\right]
 
-        where $D_k$ make of this dual frame (i.e. ``self``).
+        where :math:`D_k` make of this dual frame (i.e. ``self``).
 
         .. note::
            TODO: explain how this relates to the :meth:`.BaseFrame.analysis` method.

--- a/povm_toolbox/quantum_info/base/base_frame.py
+++ b/povm_toolbox/quantum_info/base/base_frame.py
@@ -87,7 +87,7 @@ class BaseFrame(ABC, Generic[LabelT]):
 
         Args:
             hermitian_op: a hermitian operator whose frame coefficients to compute.
-            frame_op_idx: TODO.
+            frame_op_idx: label(s) indicating which frame coefficients are queried.
 
         Returns:
             TODO explain the different output types and how these represent the frame coefficients

--- a/povm_toolbox/quantum_info/base/base_frame.py
+++ b/povm_toolbox/quantum_info/base/base_frame.py
@@ -83,13 +83,30 @@ class BaseFrame(ABC, Generic[LabelT]):
         hermitian_op: SparsePauliOp | Operator,
         frame_op_idx: LabelT | set[LabelT] | None = None,
     ) -> float | dict[LabelT, float] | np.ndarray:
-        """Return the frame coefficients of ``hermitian_op``.
+        r"""Return the frame coefficients of ``hermitian_op``.
+
+        This method implements the *analysis operator* :math:`A` of the frame :math:`\{F_k\}_k`:
+
+        .. math::
+            A: \mathcal{O} \mapsto \{ \mathrm{Tr}\left[F_k \mathcal{O} \right] \}_k,
+
+        where :math:`c_k =  \mathrm{Tr}\left[F_k \mathcal{O} \right]` are called the *frame coefficients*
+        of the Hermitian operator :math:`\mathcal{O}`.
 
         Args:
             hermitian_op: a hermitian operator whose frame coefficients to compute.
-            frame_op_idx: label(s) indicating which frame coefficients are queried.
+            frame_op_idx: label or set of labels indicating which coefficients are
+            queried. If ``None``, all coefficients are queried.
 
         Returns:
-            TODO explain the different output types and how these represent the frame coefficients
-            of the provided hermitian operator.
+            Frame coefficients, specified by ``frame_op_idx``, of the Hermitian operator ``hermitian_op``.
+            If a specific coefficient was queried, a ``float`` is returned. If a specific set of
+            coefficients was queried, a dictionary mapping labels to coefficients is returned. If all
+            coefficients were queried, an array with all coefficients is returned.
+
+        Raises:
+            TypeError: when the provided single or sequence of labels ``frame_op_idx`` does not have
+                a valid type.
+            ValueError: when the dimension of the provided ``hermitian_op`` does not match the dimension
+                of the frame operators.
         """

--- a/povm_toolbox/quantum_info/base/base_frame.py
+++ b/povm_toolbox/quantum_info/base/base_frame.py
@@ -38,21 +38,27 @@ class BaseFrame(ABC, Generic[LabelT]):
 
     If a set of operators does not span the entire Hilbert space, it can still be considered as a
     frame on the subspace it spans.
+
+    .. warning::
+       TODO: missing explanation of what an ``effect`` is in order to make the following
+       documentation easier to understand. We should check whether the notion of an `effect` is
+       needed and if/how it differs from `operator` (e.g. :attr:`num_operators` seems to mix these
+       names interchangeably).
     """
 
     @property
     @abstractmethod
     def informationally_complete(self) -> bool:
-        """Return if the frame spans the entire Hilbert space."""
+        """If the frame spans the entire Hilbert space."""
 
     @property
     @abstractmethod
     def dimension(self) -> int:
-        """Give the dimension of the Hilbert space on which the effects act."""
+        """The dimension of the Hilbert space on which the effects act."""
 
     @property
     def num_subsystems(self) -> int:
-        r"""Return the number of subsystems which the effects act on.
+        r"""The number of subsystems which the effects act on.
 
         For qubits, this is always :math:`\log_2(`:attr:`.dimension`:math:`)`.
         """
@@ -61,7 +67,7 @@ class BaseFrame(ABC, Generic[LabelT]):
     @property
     @abstractmethod
     def num_operators(self) -> int:
-        """Give the number of effects of the frame."""
+        """The number of effects of the frame."""
 
     @abstractmethod
     def _check_validity(self) -> None:
@@ -77,4 +83,13 @@ class BaseFrame(ABC, Generic[LabelT]):
         hermitian_op: SparsePauliOp | Operator,
         frame_op_idx: LabelT | set[LabelT] | None = None,
     ) -> float | dict[LabelT, float] | np.ndarray:
-        """Return the frame coefficients of ``hermitian_op``."""
+        """Return the frame coefficients of ``hermitian_op``.
+
+        Args:
+            hermitian_op: a hermitian operator whose frame coefficients to compute.
+            frame_op_idx: TODO.
+
+        Returns:
+            TODO explain the different output types and how these represent the frame coefficients
+            of the provided hermitian operator.
+        """

--- a/povm_toolbox/quantum_info/base/base_frame.py
+++ b/povm_toolbox/quantum_info/base/base_frame.py
@@ -38,12 +38,6 @@ class BaseFrame(ABC, Generic[LabelT]):
 
     If a set of operators does not span the entire Hilbert space, it can still be considered as a
     frame on the subspace it spans.
-
-    .. warning::
-       TODO: missing explanation of what an ``effect`` is in order to make the following
-       documentation easier to understand. We should check whether the notion of an `effect` is
-       needed and if/how it differs from `operator` (e.g. :attr:`num_operators` seems to mix these
-       names interchangeably).
     """
 
     @property
@@ -54,11 +48,11 @@ class BaseFrame(ABC, Generic[LabelT]):
     @property
     @abstractmethod
     def dimension(self) -> int:
-        """The dimension of the Hilbert space on which the effects act."""
+        """The dimension of the Hilbert space on which the frame operators act."""
 
     @property
     def num_subsystems(self) -> int:
-        r"""The number of subsystems which the effects act on.
+        r"""The number of subsystems which the frame operators act on.
 
         For qubits, this is always :math:`\log_2(`:attr:`.dimension`:math:`)`.
         """
@@ -67,7 +61,7 @@ class BaseFrame(ABC, Generic[LabelT]):
     @property
     @abstractmethod
     def num_operators(self) -> int:
-        """The number of effects of the frame."""
+        """The number of frame operators of the frame."""
 
     @abstractmethod
     def _check_validity(self) -> None:
@@ -75,7 +69,7 @@ class BaseFrame(ABC, Generic[LabelT]):
 
     @abstractmethod
     def __len__(self) -> int:
-        """Return the number of effects of the POVM."""
+        """Return the number of frame operators of the POVM."""
 
     @abstractmethod
     def analysis(

--- a/povm_toolbox/quantum_info/base/base_frame.py
+++ b/povm_toolbox/quantum_info/base/base_frame.py
@@ -84,23 +84,23 @@ class BaseFrame(ABC, Generic[LabelT]):
         .. math::
             A: \mathcal{O} \mapsto \{ \mathrm{Tr}\left[F_k \mathcal{O} \right] \}_k,
 
-        where :math:`c_k =  \mathrm{Tr}\left[F_k \mathcal{O} \right]` are called the *frame coefficients*
-        of the Hermitian operator :math:`\mathcal{O}`.
+        where :math:`c_k =  \mathrm{Tr}\left[F_k \mathcal{O} \right]` are called the *frame
+        coefficients* of the Hermitian operator :math:`\mathcal{O}`.
 
         Args:
             hermitian_op: a hermitian operator whose frame coefficients to compute.
             frame_op_idx: label or set of labels indicating which coefficients are
-            queried. If ``None``, all coefficients are queried.
+                queried. If ``None``, all coefficients are queried.
 
         Returns:
-            Frame coefficients, specified by ``frame_op_idx``, of the Hermitian operator ``hermitian_op``.
-            If a specific coefficient was queried, a ``float`` is returned. If a specific set of
-            coefficients was queried, a dictionary mapping labels to coefficients is returned. If all
-            coefficients were queried, an array with all coefficients is returned.
+            Frame coefficients, specified by ``frame_op_idx``, of the Hermitian operator
+            ``hermitian_op``. If a specific coefficient was queried, a ``float`` is returned. If a
+            specific set of coefficients was queried, a dictionary mapping labels to coefficients is
+            returned. If all coefficients were queried, an array with all coefficients is returned.
 
         Raises:
             TypeError: when the provided single or sequence of labels ``frame_op_idx`` does not have
                 a valid type.
-            ValueError: when the dimension of the provided ``hermitian_op`` does not match the dimension
-                of the frame operators.
+            ValueError: when the dimension of the provided ``hermitian_op`` does not match the
+                dimension of the frame operators.
         """

--- a/povm_toolbox/quantum_info/base/base_povm.py
+++ b/povm_toolbox/quantum_info/base/base_povm.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO."""
+"""BasePOVM."""
 
 from __future__ import annotations
 
@@ -22,13 +22,14 @@ from .base_frame import BaseFrame, LabelT
 
 
 class BasePOVM(BaseFrame[LabelT], ABC):
-    """Abstract base class that contains all methods that any specific POVM subclass should implement."""
+    """Abstract base class that contains all methods that any specific POVM should implement."""
 
     default_dual_class: type[BaseDual]
+    """The default :class:`.BaseDual` associated with this POVM."""
 
     @property
     def num_outcomes(self) -> int:
-        """Give the number of outcomes of the POVM."""
+        """The number of outcomes of the POVM."""
         return self.num_operators
 
     @abstractmethod
@@ -37,5 +38,19 @@ class BasePOVM(BaseFrame[LabelT], ABC):
         rho: SparsePauliOp | DensityMatrix | Statevector,
         outcome_idx: LabelT | set[LabelT] | None = None,
     ) -> float | dict[LabelT, float] | np.ndarray:
-        """Return the outcome probabilities given a state rho."""
+        r"""Return the outcome probabilities given a state, $\rho$.
+
+        .. note::
+           TODO: explain how this relates to the :meth:`.BaseFrame.analysis` method.
+
+        Args:
+            rho: the state for which to compute the outcome probabilities.
+            outcome_idx: TODO.
+
+        Returns:
+            TODO explain the different output types and how these represent the outcome
+            probabilities of the provided state.
+        """
+        # TODO: why is this method labeled abstract but still has an implementation? One of these
+        # should be removed.
         return self.analysis(rho, outcome_idx)

--- a/povm_toolbox/quantum_info/base/base_povm.py
+++ b/povm_toolbox/quantum_info/base/base_povm.py
@@ -38,14 +38,18 @@ class BasePOVM(BaseFrame[LabelT], ABC):
         rho: SparsePauliOp | DensityMatrix | Statevector,
         outcome_idx: LabelT | set[LabelT] | None = None,
     ) -> float | dict[LabelT, float] | np.ndarray:
-        r"""Return the outcome probabilities given a state, $\rho$.
+        r"""Return the outcome probabilities given a state, :math:`\rho`.
+
+        Each outcome :math:`k` is associated with an effect :math:`M_k` of the POVM. The probability
+        of obtaining the outcome :math:`k` when measuring a state ``rho`` is given by
+        :math:`p_k = Tr[M_k \rho]`.
 
         .. note::
            TODO: explain how this relates to the :meth:`.BaseFrame.analysis` method.
 
         Args:
             rho: the state for which to compute the outcome probabilities.
-            outcome_idx: TODO.
+            outcome_idx: label(s) indicating which outcome probabilities are queried.
 
         Returns:
             TODO explain the different output types and how these represent the outcome

--- a/povm_toolbox/quantum_info/base/base_povm.py
+++ b/povm_toolbox/quantum_info/base/base_povm.py
@@ -12,10 +12,10 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABC
 
 import numpy as np
-from qiskit.quantum_info import DensityMatrix, SparsePauliOp, Statevector
+from qiskit.quantum_info import DensityMatrix, Operator, SparsePauliOp, Statevector
 
 from .base_dual import BaseDual
 from .base_frame import BaseFrame, LabelT
@@ -32,7 +32,6 @@ class BasePOVM(BaseFrame[LabelT], ABC):
         """The number of outcomes of the POVM."""
         return self.num_operators
 
-    @abstractmethod
     def get_prob(
         self,
         rho: SparsePauliOp | DensityMatrix | Statevector,
@@ -42,19 +41,25 @@ class BasePOVM(BaseFrame[LabelT], ABC):
 
         Each outcome :math:`k` is associated with an effect :math:`M_k` of the POVM. The probability
         of obtaining the outcome :math:`k` when measuring a state ``rho`` is given by
-        :math:`p_k = Tr[M_k \rho]`.
+        :math:`p_k = \text{Tr}\left[M_k \rho\right]`.
 
         .. note::
-           TODO: explain how this relates to the :meth:`.BaseFrame.analysis` method.
+            In the frame theory formalism, the mapping
+            :math:`A: \rho \mapsto \{\text{Tr}\left[M_k \rho\right]\}_k`
+            is referred to as the *analysis operator*, which is implemented by
+            the :meth:`.analysis` method.
 
         Args:
             rho: the state for which to compute the outcome probabilities.
-            outcome_idx: label(s) indicating which outcome probabilities are queried.
+            outcome_idx: label or set of labels indicating which outcome probabilities
+                are queried. If ``None``, all outcome probabilities are queried.
 
         Returns:
-            TODO explain the different output types and how these represent the outcome
-            probabilities of the provided state.
+            Probabilities of obtaining the outcome(s) specified by ``outcome_idx`` over the state ``rho``.
+            If a specific outcome was queried, a ``float`` is returned. If a specific set of outcomes was
+            queried, a dictionary mapping outcomes to probabilities is returned. If all outcomes were
+            queried, an array with all probabilities is returned.
         """
-        # TODO: why is this method labeled abstract but still has an implementation? One of these
-        # should be removed.
+        if isinstance(rho, (DensityMatrix, Statevector)):
+            rho = Operator(rho)
         return self.analysis(rho, outcome_idx)

--- a/povm_toolbox/quantum_info/base/base_povm.py
+++ b/povm_toolbox/quantum_info/base/base_povm.py
@@ -55,10 +55,10 @@ class BasePOVM(BaseFrame[LabelT], ABC):
                 are queried. If ``None``, all outcome probabilities are queried.
 
         Returns:
-            Probabilities of obtaining the outcome(s) specified by ``outcome_idx`` over the state ``rho``.
-            If a specific outcome was queried, a ``float`` is returned. If a specific set of outcomes was
-            queried, a dictionary mapping outcomes to probabilities is returned. If all outcomes were
-            queried, an array with all probabilities is returned.
+            Probabilities of obtaining the outcome(s) specified by ``outcome_idx`` over the state
+            ``rho``. If a specific outcome was queried, a ``float`` is returned. If a specific set
+            of outcomes was queried, a dictionary mapping outcomes to probabilities is returned. If
+            all outcomes were queried, an array with all probabilities is returned.
         """
         if isinstance(rho, (DensityMatrix, Statevector)):
             rho = Operator(rho)

--- a/povm_toolbox/quantum_info/multi_qubit_dual.py
+++ b/povm_toolbox/quantum_info/multi_qubit_dual.py
@@ -12,6 +12,13 @@
 
 from __future__ import annotations
 
+import sys
+
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override
+
 import numpy as np
 from qiskit.quantum_info import Operator, SparsePauliOp
 
@@ -28,16 +35,19 @@ class MultiQubitDual(MultiQubitFrame, BaseDual):
     :class:`~qiskit.quantum_info.Operator`.
     """
 
+    @override
     def get_omegas(
         self, observable: SparsePauliOp | Operator, outcome_idx: int | set[int] | None = None
     ) -> float | dict[int, float] | np.ndarray:
         return self.analysis(observable, outcome_idx)
 
+    @override
     def is_dual_to(self, frame: BaseFrame) -> bool:
         if isinstance(frame, MultiQubitFrame):
             return np.allclose(frame @ np.conj(self).T, np.eye(self.dimension**2), atol=1e-6)
         raise NotImplementedError
 
+    @override
     @classmethod
     def build_dual_from_frame(
         cls, frame: BaseFrame, alphas: tuple[float, ...] | None = None

--- a/povm_toolbox/quantum_info/multi_qubit_dual.py
+++ b/povm_toolbox/quantum_info/multi_qubit_dual.py
@@ -20,7 +20,7 @@ else:
     from typing import override
 
 import numpy as np
-from qiskit.quantum_info import Operator, SparsePauliOp
+from qiskit.quantum_info import Operator
 
 from povm_toolbox.utilities import double_ket_to_matrix
 
@@ -34,12 +34,6 @@ class MultiQubitDual(MultiQubitFrame, BaseDual):
     This is a representation of a dual frame. Its elements are specified as a list of
     :class:`~qiskit.quantum_info.Operator`.
     """
-
-    @override
-    def get_omegas(
-        self, observable: SparsePauliOp | Operator, outcome_idx: int | set[int] | None = None
-    ) -> float | dict[int, float] | np.ndarray:
-        return self.analysis(observable, outcome_idx)
 
     @override
     def is_dual_to(self, frame: BaseFrame) -> bool:

--- a/povm_toolbox/quantum_info/multi_qubit_dual.py
+++ b/povm_toolbox/quantum_info/multi_qubit_dual.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO."""
+"""MultiQubitDual."""
 
 from __future__ import annotations
 
@@ -22,34 +22,18 @@ from .multi_qubit_frame import MultiQubitFrame
 
 
 class MultiQubitDual(MultiQubitFrame, BaseDual):
-    """Class that collects all information that any MultiQubit Dual should specify.
+    """Class that collects all information that any Dual over multiple qubits should specify.
 
-    This is a representation of a dual frame. Its elements are specified as a list
-    of :class:`~qiskit.quantum_info.Operator`.
+    This is a representation of a dual frame. Its elements are specified as a list of
+    :class:`~qiskit.quantum_info.Operator`.
     """
 
     def get_omegas(
         self, observable: SparsePauliOp | Operator, outcome_idx: int | set[int] | None = None
     ) -> float | dict[int, float] | np.ndarray:
-        r"""Return the decomposition weights of the provided observable into the POVM effects to which ``self`` is a dual.
-
-        Here the POVM itself is not explicitly needed, its dual is sufficient. Given
-        an observable :math:`O` which is in the span of a given POVM, one can write the
-        observable :math:`O` as the weighted sum of the POVM effects, :math:`O = \sum_k w_k M_k`
-        for real weights :math:`w_k`. There might be infinitely many valid sets of weight.
-        This method returns a possible set of weights.
-
-        Args:
-            observable: the observable to be decomposed into the POVM effects.
-            outcome_idx: label(s) indicating which decomposition weights are queried.
-
-        Returns:
-            An array of decomposition weights.
-        """
         return self.analysis(observable, outcome_idx)
 
     def is_dual_to(self, frame: BaseFrame) -> bool:
-        """Check if ``self`` is a dual to another frame."""
         if isinstance(frame, MultiQubitFrame):
             return np.allclose(frame @ np.conj(self).T, np.eye(self.dimension**2), atol=1e-6)
         raise NotImplementedError
@@ -58,17 +42,6 @@ class MultiQubitDual(MultiQubitFrame, BaseDual):
     def build_dual_from_frame(
         cls, frame: BaseFrame, alphas: tuple[float, ...] | None = None
     ) -> MultiQubitDual:
-        """Construct a dual frame to another frame.
-
-        Args:
-            frame: the primal frame from which we will build the dual frame.
-            alphas: parameters of the frame super-operator used to build the
-                dual frame. If None, the parameters are set as the traces of
-                each operator in the primal frame.
-
-        Returns:
-            A multi-qubit dual frame to the supplied ``frame``.
-        """
         if isinstance(frame, MultiQubitFrame):
             # Set default values for alphas if none is provided.
             if alphas is None:

--- a/povm_toolbox/quantum_info/multi_qubit_frame.py
+++ b/povm_toolbox/quantum_info/multi_qubit_frame.py
@@ -212,7 +212,7 @@ class MultiQubitFrame(BaseFrame[int]):
         :math:`|\tilde{\psi} \rangle = \sqrt{\gamma} |\psi \rangle`.
 
         .. note::
-           TODO: what is $\gamma$ in the above?
+           TODO: what is :math:`\gamma` in the above?
 
         Args:
             frame_vectors: list of vectors :math:`|\tilde{\psi} \rangle`. The length of the list

--- a/povm_toolbox/quantum_info/multi_qubit_frame.py
+++ b/povm_toolbox/quantum_info/multi_qubit_frame.py
@@ -200,9 +200,10 @@ class MultiQubitFrame(BaseFrame[int]):
     def from_vectors(cls, frame_vectors: np.ndarray) -> Self:
         r"""Initialize a frame from non-normalized bloch vectors.
 
-        The non-normalized Bloch vectors are given by :math:`|\tilde{\psi}_k \rangle = \sqrt{\gamma_k}
-        |\psi_k \rangle`. The resulting frame operators are :math:`F_k = \gamma_k |\psi_k \rangle
-        \langle \psi_k |` where :math:`\gamma_k` is the trace of the :math:`k`'th frame operator.
+        The non-normalized Bloch vectors are given by :math:`|\tilde{\psi}_k \rangle =
+        \sqrt{\gamma_k} |\psi_k \rangle`. The resulting frame operators are :math:`F_k = \gamma_k
+        |\psi_k \rangle \langle \psi_k |` where :math:`\gamma_k` is the trace of the :math:`k`'th
+        frame operator.
 
         Args:
             frame_vectors: list of vectors :math:`|\tilde{\psi_k} \rangle`. The length of the list

--- a/povm_toolbox/quantum_info/multi_qubit_frame.py
+++ b/povm_toolbox/quantum_info/multi_qubit_frame.py
@@ -200,19 +200,15 @@ class MultiQubitFrame(BaseFrame[int]):
     def from_vectors(cls, frame_vectors: np.ndarray) -> Self:
         r"""Initialize a frame from non-normalized bloch vectors.
 
-        The non-normalized Boch vectors are given by
-        :math:`|\tilde{\psi} \rangle = \sqrt{\gamma} |\psi \rangle`.
-
-        .. note::
-           TODO: what is :math:`\gamma` in the above?
+        The non-normalized Bloch vectors are given by :math:`|\tilde{\psi}_k \rangle = \sqrt{\gamma_k}
+        |\psi_k \rangle`. The resulting frame operators are :math:`F_k = \gamma_k |\psi_k \rangle
+        \langle \psi_k |` where :math:`\gamma_k` is the trace of the :math:`k`'th frame operator.
 
         Args:
-            frame_vectors: list of vectors :math:`|\tilde{\psi} \rangle`. The length of the list
+            frame_vectors: list of vectors :math:`|\tilde{\psi_k} \rangle`. The length of the list
                 corresponds to the number of operators of the frame. Each vector is of shape
                 :math:`(\mathrm{dim},)` where :math:`\mathrm{dim}` is the :attr:`.dimension` of the
-                Hilbert space on which the frame acts. The resulting frame operators :math:`\Pi =
-                \gamma |\psi \rangle \langle \psi|` are of shape :math:`(\mathrm{dim},
-                \mathrm{dim})` as expected.
+                Hilbert space on which the frame acts.
 
         Returns:
             The frame corresponding to the vectors.

--- a/povm_toolbox/quantum_info/multi_qubit_frame.py
+++ b/povm_toolbox/quantum_info/multi_qubit_frame.py
@@ -68,14 +68,17 @@ class MultiQubitFrame(BaseFrame[int]):
 
     @property
     def informationally_complete(self) -> bool:
+        """If the frame spans the entire Hilbert space."""
         return self._informationally_complete
 
     @property
     def dimension(self) -> int:
+        """The dimension of the Hilbert space on which the effects act."""
         return self._dimension
 
     @property
     def num_operators(self) -> int:
+        """The number of effects of the frame."""
         return self._num_operators
 
     @property

--- a/povm_toolbox/quantum_info/multi_qubit_frame.py
+++ b/povm_toolbox/quantum_info/multi_qubit_frame.py
@@ -19,6 +19,11 @@ if sys.version_info < (3, 11):
 else:
     from typing import Self
 
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override
+
 import numpy as np
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info import Operator, SparsePauliOp
@@ -168,28 +173,12 @@ class MultiQubitFrame(BaseFrame[int]):
         """
         return self._array
 
+    @override
     def analysis(
         self,
         hermitian_op: SparsePauliOp | Operator,
         frame_op_idx: int | set[int] | None = None,
     ) -> float | dict[int, float] | np.ndarray:
-        r"""Return the frame coefficients given an operator ``hermitian_op``.
-
-        Given a Hermitian operator :math:`\mathcal{O}`, one can compute its frame coefficients
-        :math:`c_k = Tr[M_k \mathcal{O}]`, where :math:`M_k` is the frame operator labelled by
-        :math:`k`. In frame theory, this operation is called the "analysis operation".
-
-        Args:
-            hermitian_op: the Hermitian operator whose frame coefficient(s) are queried.
-            frame_op_idx: label(s) indicating which frame coefficients are queried.
-
-        Returns:
-            TODO explain the different output types and how these represent the frame coefficients
-            of the provided hermitian operator.
-
-        Raises:
-            TypeError: if the label(s) ``frame_op_idx`` do not have a valid type.
-        """
         if isinstance(hermitian_op, SparsePauliOp):
             hermitian_op = hermitian_op.to_operator()
         op_vectorized = np.conj(matrix_to_double_ket(hermitian_op.data))

--- a/povm_toolbox/quantum_info/multi_qubit_povm.py
+++ b/povm_toolbox/quantum_info/multi_qubit_povm.py
@@ -12,6 +12,13 @@
 
 from __future__ import annotations
 
+import sys
+
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override
+
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
@@ -69,6 +76,7 @@ class MultiQubitPOVM(MultiQubitFrame, BasePOVM):
         if not np.allclose(summed_op, np.identity(self.dimension, dtype=complex), atol=1e-5):
             raise ValueError(f"POVM operators not summing up to the identity : \n{summed_op}")
 
+    @override
     def get_prob(
         self,
         rho: SparsePauliOp | DensityMatrix | Statevector,

--- a/povm_toolbox/quantum_info/multi_qubit_povm.py
+++ b/povm_toolbox/quantum_info/multi_qubit_povm.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO."""
+"""MultiQubitPOVM."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from .multi_qubit_frame import MultiQubitFrame
 
 
 class MultiQubitPOVM(MultiQubitFrame, BasePOVM):
-    """Class that collects all information that any MultiQubit POVM should specify.
+    """Class that collects all information that any POVM over multiple qubits should specify.
 
     This is a representation of a positive operator-valued measure (POVM). The effects are
     specified as a list of :class:`~qiskit.quantum_info.Operator`.
@@ -32,7 +32,7 @@ class MultiQubitPOVM(MultiQubitFrame, BasePOVM):
     default_dual_class = MultiQubitDual
 
     def _check_validity(self) -> None:
-        r"""Check if POVM axioms are fulfilled.
+        """Check if POVM axioms are fulfilled.
 
         Raises:
             ValueError: if any of the POVM operators is not hermitian.
@@ -59,18 +59,6 @@ class MultiQubitPOVM(MultiQubitFrame, BasePOVM):
         rho: SparsePauliOp | DensityMatrix | Statevector,
         outcome_idx: int | set[int] | None = None,
     ) -> float | dict[int, float] | np.ndarray:
-        r"""Return the outcome probabilities given a state ``rho``.
-
-        Each outcome :math:`k` is associated with an effect :math:`M_k` of the POVM. The probability of obtaining
-        the outcome :math:`k` when measuring a state ``rho`` is given by :math:`p_k = Tr[M_k \rho]`.
-
-        Args:
-            rho: the input state over which to compute the outcome probabilities.
-            outcome_idx: label(s) indicating which outcome probabilities are queried.
-
-        Returns:
-            An array of probabilities. The length of the array is given by the number of outcomes of the POVM.
-        """
         if not isinstance(rho, SparsePauliOp):
             rho = Operator(rho)
         return self.analysis(rho, outcome_idx)
@@ -85,7 +73,12 @@ class MultiQubitPOVM(MultiQubitFrame, BasePOVM):
         font_size: float | None = None,
         colorbar: bool = False,
     ) -> Figure:
-        """Draw the Bloch vectors of a :class:`.MultiQubitPOVM` instance.
+        """Plot the Bloch vector of each effect of the POVM.
+
+        .. warning::
+           This method is not actually implemented for a generic multi-qubit POVM. However, it is
+           available for single-qubit POVMs (see :meth:`.SingleQubitPOVM.draw_bloch`) as well as
+           products of such single-qubit POVMs (see :meth:`.ProductPOVM.draw_bloch`).
 
         Args:
             title: A string that represents the plot title.
@@ -96,5 +89,8 @@ class MultiQubitPOVM(MultiQubitFrame, BasePOVM):
             colorbar: If ``True``, normalize the vectors on the Bloch sphere and
                 add a colormap to keep track of the norm of the vectors. It can
                 help to visualize the vector if they have a small norm.
+
+        Returns:
+            The resulting figure.
         """
         raise NotImplementedError

--- a/povm_toolbox/quantum_info/multi_qubit_povm.py
+++ b/povm_toolbox/quantum_info/multi_qubit_povm.py
@@ -82,7 +82,7 @@ class MultiQubitPOVM(MultiQubitFrame, BasePOVM):
         rho: SparsePauliOp | DensityMatrix | Statevector,
         outcome_idx: int | set[int] | None = None,
     ) -> float | dict[int, float] | np.ndarray:
-        if not isinstance(rho, SparsePauliOp):
+        if isinstance(rho, (DensityMatrix, Statevector)):
             rho = Operator(rho)
         return self.analysis(rho, outcome_idx)
 

--- a/povm_toolbox/quantum_info/multi_qubit_povm.py
+++ b/povm_toolbox/quantum_info/multi_qubit_povm.py
@@ -27,6 +27,21 @@ class MultiQubitPOVM(MultiQubitFrame, BasePOVM):
 
     This is a representation of a positive operator-valued measure (POVM). The effects are
     specified as a list of :class:`~qiskit.quantum_info.Operator`.
+
+    Below is a simple example showing how you define some 2-qubit POVM:
+
+    >>> from qiskit.quantum_info import Operator
+    >>> from povm_toolbox.quantum_info import MultiQubitPOVM
+    >>> povm = MultiQubitPOVM(
+    ...     [
+    ...         Operator.from_label("00"),
+    ...         Operator.from_label("01"),
+    ...         Operator.from_label("10"),
+    ...         Operator.from_label("11"),
+    ...     ]
+    ... )
+    >>> print(povm)
+    MultiQubitPOVM(num_qubits=2)<4> at 0x...
     """
 
     default_dual_class = MultiQubitDual

--- a/povm_toolbox/quantum_info/multi_qubit_povm.py
+++ b/povm_toolbox/quantum_info/multi_qubit_povm.py
@@ -12,17 +12,9 @@
 
 from __future__ import annotations
 
-import sys
-
-if sys.version_info < (3, 12):
-    from typing_extensions import override
-else:
-    from typing import override
-
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
-from qiskit.quantum_info import DensityMatrix, Operator, SparsePauliOp, Statevector
 
 from .base import BasePOVM
 from .multi_qubit_dual import MultiQubitDual
@@ -75,16 +67,6 @@ class MultiQubitPOVM(MultiQubitFrame, BasePOVM):
 
         if not np.allclose(summed_op, np.identity(self.dimension, dtype=complex), atol=1e-5):
             raise ValueError(f"POVM operators not summing up to the identity : \n{summed_op}")
-
-    @override
-    def get_prob(
-        self,
-        rho: SparsePauliOp | DensityMatrix | Statevector,
-        outcome_idx: int | set[int] | None = None,
-    ) -> float | dict[int, float] | np.ndarray:
-        if isinstance(rho, (DensityMatrix, Statevector)):
-            rho = Operator(rho)
-        return self.analysis(rho, outcome_idx)
 
     def draw_bloch(
         self,

--- a/povm_toolbox/quantum_info/product_dual.py
+++ b/povm_toolbox/quantum_info/product_dual.py
@@ -32,41 +32,15 @@ class ProductDual(ProductFrame[MultiQubitDual], BaseDual):
 
     A product Dual :math:`D` is made of local Duals :math:`D1, D2, ...` acting on respective
     subsystems. Each global effect can be written as the tensor product of local effects,
-    :math:`D_{k_1, k_2, ...} = D1_{k_1} \otimes D2_{k__2} \otimes ...`.
+    :math:`D_{k_1, k_2, ...} = D1_{k_1} \otimes D2_{k__2} \otimes \cdots`.
     """
 
+    @override
     def get_omegas(
         self,
         observable: SparsePauliOp | Operator,
         outcome_idx: tuple[int, ...] | set[tuple[int, ...]] | None = None,
     ) -> float | dict[tuple[int, ...], float] | np.ndarray:
-        r"""Return the decomposition weights of the provided observable.
-
-        .. note::
-           TODO: align this docstring with that of :class:`.BaseFrame`.
-
-        Here the POVM itself is not explicitly needed, its dual is sufficient. Given
-        an observable :math:`O` which is in the span of a given POVM, one can write the
-        observable :math:`O` as the weighted sum of the POVM effects, :math:`O = \sum_k w_k M_k`
-        for real weights :math:`w_k`. There might be infinitely many valid sets of weight.
-        This method returns a possible set of weights.
-
-        Args:
-            observable: the observable to be decomposed into the POVM effects.
-            outcome_idx: the outcomes for which one queries the probability. Each outcome is labeled
-                by a tuple of integers (one index per local POVM). One can query a single outcome or a
-                set of outcomes. If ``None``, all outcomes are queried.
-
-
-        Returns:
-            Decomposition weight(s) associated to the effect(s) specified by ``outcome_idx``.
-            If a specific outcome was queried, a ``float`` is returned. If a specific set of outcomes was
-            queried, a dictionary mapping outcome labels to weights is returned. If all outcomes were
-            queried, a high-dimensional array with one dimension per local POVM stored inside this
-            :class:`.ProductPOVM` instance is returned. The length of each dimension is given by
-            the number of outcomes of the POVM encoded along that axis.
-        """
-        # TODO: check that observable is Hermitian ?
         return self.analysis(observable, outcome_idx)
 
     @override

--- a/povm_toolbox/quantum_info/product_dual.py
+++ b/povm_toolbox/quantum_info/product_dual.py
@@ -19,9 +19,6 @@ if sys.version_info < (3, 12):
 else:
     from typing import override
 
-import numpy as np
-from qiskit.quantum_info import Operator, SparsePauliOp
-
 from .base import BaseDual, BaseFrame
 from .multi_qubit_dual import MultiQubitDual
 from .product_frame import ProductFrame
@@ -34,14 +31,6 @@ class ProductDual(ProductFrame[MultiQubitDual], BaseDual):
     subsystems. Each global effect can be written as the tensor product of local effects,
     :math:`D_{k_1, k_2, ...} = D1_{k_1} \otimes D2_{k__2} \otimes \cdots`.
     """
-
-    @override
-    def get_omegas(
-        self,
-        observable: SparsePauliOp | Operator,
-        outcome_idx: tuple[int, ...] | set[tuple[int, ...]] | None = None,
-    ) -> float | dict[tuple[int, ...], float] | np.ndarray:
-        return self.analysis(observable, outcome_idx)
 
     @override
     def is_dual_to(self, frame: BaseFrame) -> bool:

--- a/povm_toolbox/quantum_info/product_dual.py
+++ b/povm_toolbox/quantum_info/product_dual.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO."""
+"""ProductDual."""
 
 from __future__ import annotations
 
@@ -23,10 +23,9 @@ from .product_frame import ProductFrame
 class ProductDual(ProductFrame[MultiQubitDual], BaseDual):
     r"""Class to represent a set of product Dual operators.
 
-    A product Dual :math:`D` is made of local Dual :math:`D1, D2, ...` acting
-    on respective subsystems. Each global effect can be written as the tensor
-    product of local effects,
-    :math:`D_{k_1, k_2, ...} = D1_{k_1} \otimes D2_{k2} \otimes ...`.
+    A product Dual :math:`D` is made of local Duals :math:`D1, D2, ...` acting on respective
+    subsystems. Each global effect can be written as the tensor product of local effects,
+    :math:`D_{k_1, k_2, ...} = D1_{k_1} \otimes D2_{k__2} \otimes ...`.
     """
 
     def get_omegas(
@@ -34,7 +33,10 @@ class ProductDual(ProductFrame[MultiQubitDual], BaseDual):
         observable: SparsePauliOp | Operator,
         outcome_idx: tuple[int, ...] | set[tuple[int, ...]] | None = None,
     ) -> float | dict[tuple[int, ...], float] | np.ndarray:
-        r"""Return the decomposition weights of the provided observable into the POVM effects to which ``self`` is a dual.
+        r"""Return the decomposition weights of the provided observable.
+
+        .. note::
+           TODO: align this docstring with that of :class:`.BaseFrame`.
 
         Here the POVM itself is not explicitly needed, its dual is sufficient. Given
         an observable :math:`O` which is in the span of a given POVM, one can write the
@@ -61,7 +63,6 @@ class ProductDual(ProductFrame[MultiQubitDual], BaseDual):
         return self.analysis(observable, outcome_idx)
 
     def is_dual_to(self, frame: BaseFrame) -> bool:
-        """Check if ``self`` is a dual to another frame."""
         if isinstance(frame, ProductFrame) and set(self.sub_systems) == set(frame.sub_systems):
             return all([self[idx].is_dual_to(frame[idx]) for idx in self.sub_systems])
         # TODO: maybe differentiate two distinct cases:
@@ -76,18 +77,6 @@ class ProductDual(ProductFrame[MultiQubitDual], BaseDual):
     def build_dual_from_frame(
         cls, frame: BaseFrame, alphas: tuple[tuple[float, ...] | None, ...] | None = None
     ) -> ProductDual:
-        """Construct a dual frame to another frame.
-
-        Args:
-            frame: the primal frame from which we will build the dual frame.
-            alphas: parameters of the local frame super-operators used to build
-                the local dual frames which form together the product dual frame.
-                If None, the parameters are set as the traces of each local operator
-                in each of the primal frames.
-
-        Returns:
-            A product dual frame to the supplied ``frame``.
-        """
         dual_operators = {}
         if isinstance(frame, ProductFrame):
             if alphas is None:

--- a/povm_toolbox/quantum_info/product_dual.py
+++ b/povm_toolbox/quantum_info/product_dual.py
@@ -12,6 +12,13 @@
 
 from __future__ import annotations
 
+import sys
+
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override
+
 import numpy as np
 from qiskit.quantum_info import Operator, SparsePauliOp
 
@@ -62,6 +69,7 @@ class ProductDual(ProductFrame[MultiQubitDual], BaseDual):
         # TODO: check that observable is Hermitian ?
         return self.analysis(observable, outcome_idx)
 
+    @override
     def is_dual_to(self, frame: BaseFrame) -> bool:
         if isinstance(frame, ProductFrame) and set(self.sub_systems) == set(frame.sub_systems):
             return all([self[idx].is_dual_to(frame[idx]) for idx in self.sub_systems])
@@ -73,6 +81,7 @@ class ProductDual(ProductFrame[MultiQubitDual], BaseDual):
         #      have not implemented the check for this. Then we should raise an NotImplementedError.
         raise NotImplementedError
 
+    @override
     @classmethod
     def build_dual_from_frame(
         cls, frame: BaseFrame, alphas: tuple[tuple[float, ...] | None, ...] | None = None

--- a/povm_toolbox/quantum_info/product_dual.py
+++ b/povm_toolbox/quantum_info/product_dual.py
@@ -48,11 +48,12 @@ class ProductDual(ProductFrame[MultiQubitDual], BaseDual):
         if isinstance(frame, ProductFrame) and set(self.sub_systems) == set(frame.sub_systems):
             return all([self[idx].is_dual_to(frame[idx]) for idx in self.sub_systems])
         # TODO: maybe differentiate two distinct cases:
-        #   1) the subsystems are not the same, e.g. ``self`` acts on (0,) and (1,) but ``frame`` acts
-        #      on (0,) and (2,). Then we should raise an ValueError
+        #   1) the subsystems are not the same, e.g. ``self`` acts on (0,) and (1,) but ``frame``
+        #      acts on (0,) and (2,). Then we should raise an ValueError
         #   2) the subsystems are the same but differently allocated, e.g. ``self`` acts on (0,) and
-        #      (1,2) but ``frame`` on (0,1) and (2,). ``self`` could still be a valid dual frame but we
-        #      have not implemented the check for this. Then we should raise an NotImplementedError.
+        #      (1,2) but ``frame`` on (0,1) and (2,). ``self`` could still be a valid dual frame but
+        #      we have not implemented the check for this. Then we should raise an
+        #      NotImplementedError.
         raise NotImplementedError
 
     @override

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -37,7 +37,7 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
     r"""Class to represent a set of product frame operators.
 
     A product frame :math:`M` is made of local frames :math:`M_1, M2, ...` acting on respective
-    subsystems. Each global effect can be written as the tensor product of local operators,
+    subsystems. Each global operator can be written as the tensor product of local operators,
     :math:`M_{k_1, k_2, ...} = M1_{k_1} \otimes M2_{k2} \otimes \ldots`.
 
     .. note::

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -164,14 +164,17 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
 
     @property
     def informationally_complete(self) -> bool:
+        """If the frame spans the entire Hilbert space."""
         return self._informationally_complete
 
     @property
     def dimension(self) -> int:
+        """The dimension of the Hilbert space on which the effects act."""
         return self._dimension
 
     @property
     def num_operators(self) -> int:
+        """The number of effects of the frame."""
         return self._num_operators
 
     @property

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -294,20 +294,23 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
         # Assert matching operator and POVM sizes.
         if hermitian_op.num_qubits != self.num_subsystems:
             raise ValueError(
-                f"Size of the operator ({hermitian_op.num_qubits}) does not match the size of the povm ({math.log2(self.dimension)})."
+                f"Size of the operator ({hermitian_op.num_qubits}) does not match the size of the "
+                f"povm ({math.log2(self.dimension)})."
             )
 
         # If frame_op_idx is ``None``, it means all outcomes are queried
         if frame_op_idx is None:
             # Extract the number of outcomes for each local POVM.
 
-            # Create the output probability array as a high-dimensional matrix. This matrix will have
-            # its number of dimensions equal to the number of POVMs stored inside the ProductPOVM. The
-            # length of each dimension is given by the number of outcomes of the POVM encoded along it.
+            # Create the output probability array as a high-dimensional matrix. This matrix will
+            # have its number of dimensions equal to the number of POVMs stored inside the
+            # ProductPOVM. The length of each dimension is given by the number of outcomes of the
+            # POVM encoded along it.
             p_init: np.ndarray = np.zeros(self.shape, dtype=float)
 
-            # First, we iterate over all the positions of ``p_init``. This corresponds to the different
-            # probabilities for the different outcomes whose probability we want to compute.
+            # First, we iterate over all the positions of ``p_init``. This corresponds to the
+            # different probabilities for the different outcomes whose probability we want to
+            # compute.
             #   - ``m`` is the multi-dimensional index into the high-dimensional ``p_init`` array.
             for m, _ in np.ndenumerate(p_init):
                 p_init[m] = self._trace_of_prod(hermitian_op, m)

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -23,6 +23,11 @@ if sys.version_info < (3, 11):
 else:
     from typing import Self
 
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override
+
 
 import numpy as np
 from qiskit.quantum_info import Operator, SparsePauliOp
@@ -38,7 +43,7 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
 
     A product frame :math:`M` is made of local frames :math:`M1, M2, ...` acting on respective
     subsystems. Each global operator can be written as the tensor product of local operators,
-    :math:`M_{k_1, k_2, ...} = M1_{k_1} \otimes M2_{k_2} \otimes \ldots`.
+    :math:`M_{k_1, k_2, ...} = M1_{k_1} \otimes M2_{k_2} \otimes \cdots`.
 
     .. note::
        This is a base class which collects functionality common to various subclasses. As an
@@ -276,36 +281,12 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
             warnings.warn(f"Expected a real number, instead got {p_idx}.", stacklevel=2)
         return float(p_idx.real)
 
+    @override
     def analysis(
         self,
         hermitian_op: SparsePauliOp | Operator,
         frame_op_idx: tuple[int, ...] | set[tuple[int, ...]] | None = None,
     ) -> float | dict[tuple[int, ...], float] | np.ndarray:
-        """Return the frame coefficients of ``hermitian_op``.
-
-        .. note::
-           TODO: align this docstring with that of :class:`.BaseFrame`.
-
-        Args:
-            hermitian_op: TODO.
-            frame_op_idx: the outcomes for which one queries the trace. Each outcome is labeled
-                by a tuple of integers (one index per local POVM). One can query a single outcome or a
-                set of outcomes. If ``None``, all outcomes are queried.
-
-        Returns:
-            Frame coefficients, specified by ``frame_op_idx``, with respect to the Hermitian operator
-            ``hermitian_op``. If a specific coefficient was queried, a ``float`` is returned. If a
-            specific set of coefficients was queried, a dictionary mapping labels to coefficients
-            is returned. If all coefficients were queried, a high-dimensional array with one dimension
-            per local frame stored inside ``self`` is returned. The length of each dimension is given
-            by the number of operators of the frame encoded along that axis.
-
-        Raises:
-            TypeError: when the provided single or sequence of labels ``frame_op_idx`` does not have
-                a valid type.
-            ValueError: when the provided ``operator`` does not act on the same number of qubits as
-                ``self``.
-        """
         if not isinstance(hermitian_op, SparsePauliOp):
             # Convert the provided operator to a Pauli operator.
             hermitian_op = SparsePauliOp.from_operator(hermitian_op)

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO."""
+"""ProductFrame."""
 
 from __future__ import annotations
 
@@ -36,136 +36,142 @@ T = TypeVar("T", bound=MultiQubitFrame)
 class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
     r"""Class to represent a set of product frame operators.
 
-    A product frame :math:`M` is made of local frames :math:`M1, M2, ...` acting
-    on respective subsystems. Each global effect can be written as the tensor
-    product of local operators,
-    :math:`M_{k_1, k_2, ...} = M1_{k_1} \otimes M2_{k2} \otimes ...`.
+    A product frame :math:`M` is made of local frames :math:`M_1, M2, ...` acting on respective
+    subsystems. Each global effect can be written as the tensor product of local operators,
+    :math:`M_{k_1, k_2, ...} = M1_{k_1} \otimes M2_{k2} \otimes \ldots`.
+
+    .. note::
+       This is a base class which collects functionality common to various subclasses. As an
+       end-user you would not use this class directly. Check out :mod:`povm_toolbox.quantum_info`
+       for more general information.
     """
 
-    def __init__(self, povms: dict[tuple[int, ...], T]):
-        """Initialize a :class:`.ProductFrame` instance.
+    def __init__(self, frames: dict[tuple[int, ...], T]) -> None:
+        """Initialize from a mapping of local frames.
 
         Args:
-            povms: a dictionary mapping from a tuple of subsystem indices to a :class:`.MultiQubitFrame`
-                object.
+            frames: a dictionary mapping from a tuple of subsystem indices to a local frame objects.
 
         Raises:
-            ValueError: if any key in ``povms`` is not a tuple consisting of unique integers. In
-                other words, every POVM must act on a distinct set of subsystem indices which do not
-                overlap with each other.
-            ValueError: if any key in ``povms`` re-uses a previously used subsystem index. In other
-                words, all POVMs must act on mutually exclusive subsystem indices.
-            ValueError: if any key in ``povms`` does not specify the number of subsystem indices,
-                which matches the number of systems acted upon by that POVM
+            ValueError: if any key in ``frames`` is not a tuple consisting of unique integers. In
+                other words, every local frame must act on a distinct set of subsystem indices which
+                do not overlap with each other.
+            ValueError: if any key in ``frames`` re-uses a previously used subsystem index. In other
+                words, all local frames must act on mutually exclusive subsystem indices.
+            ValueError: if any key in ``frames`` does not specify the number of subsystem indices,
+                which matches the number of systems acted upon by that local frame
                 (:meth:`MultiQubitFrame.num_subsystems`).
         """
         subsystem_indices = set()
         self._dimension = 1
         self._num_operators = 1
         shape: list[int] = []
-        for idx, povm in povms.items():
+        for idx, frame in frames.items():
             idx_set = set(idx)
             if len(idx) != len(idx_set):
                 raise ValueError(
-                    "The subsystem indices acted upon by any POVM must be mutually exclusive. "
-                    f"The index '{idx}' does not fulfill this criterion."
+                    "The subsystem indices acted upon by any local frame must be mutually "
+                    f"exclusive. The index '{idx}' does not fulfill this criterion."
                 )
             if any(i in subsystem_indices for i in idx):
                 raise ValueError(
-                    "The subsystem indices acted upon by all the POVMs must be mutually exclusive. "
-                    f"However, one of the indices in '{idx}' was already encountered before."
+                    "The subsystem indices acted upon by all the local frames must be mutually "
+                    f"exclusive. However, one of the indices in '{idx}' was already encountered "
+                    "before."
                 )
-            if len(idx_set) != povm.num_subsystems:
+            if len(idx_set) != frame.num_subsystems:
                 raise ValueError(
-                    "The number of subsystem indices for a POVM must match the number of subsystems"
-                    " which it acts upon. This is not satisfied for the POVM specified to act on "
-                    f"subsystems '{idx}' but having support on '{povm.num_subsystems}' subsystems."
+                    "The number of subsystem indices for a local frame must match the number of "
+                    "subsystems which it acts upon. This is not satisfied for the local frame "
+                    f"specified to act on subsystems '{idx}' but having support on "
+                    f"'{frame.num_subsystems}' subsystems."
                 )
             subsystem_indices.update(idx_set)
-            self._dimension *= povm.dimension
-            self._num_operators *= povm.num_operators
-            shape.append(povm.num_operators)
+            self._dimension *= frame.dimension
+            self._num_operators *= frame.num_operators
+            shape.append(frame.num_operators)
 
         self._informationally_complete: bool = all(
-            [povm.informationally_complete for povm in povms.values()]
+            [frame.informationally_complete for frame in frames.values()]
         )
 
-        self._povms = povms
+        self._frames = frames
         self._shape: tuple[int, ...] = tuple(shape)
 
         self._check_validity()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return the string representation of a :class:`.ProductFrame` instance."""
-        f_repr = "\n   " + "\n   ".join(f"{name}: {value}" for name, value in self._povms.items())
-        return f"{self.__class__.__name__}(num_subsystems={self.num_subsystems})<{','.join(map(str, self.shape))}>:{f_repr}"
+        f_repr = "\n   " + "\n   ".join(f"{name}: {value}" for name, value in self._frames.items())
+        return (
+            f"{self.__class__.__name__}(num_subsystems={self.num_subsystems})"
+            f"<{','.join(map(str, self.shape))}>:{f_repr}"
+        )
 
     @classmethod
-    def from_list(cls, povms: Sequence[T]) -> Self:
+    def from_list(cls, frames: Sequence[T]) -> Self:
         """Construct a :class:`.ProductFrame` from a list of :class:`.MultiQubitFrame` objects.
 
-        This is a convenience method to simplify the construction of a :class:`.ProductPOVM` for the cases
-        in which the POVM objects act on a sequential order of subsystems. In other words, this
-        method converts the sequence of POVMs to a dictionary of POVMs in accordance with the input
-        to :meth:`.ProductFrame.__init__` by using the positions along the sequence as subsystem
-        indices.
+        This is a convenience method to simplify the construction of a :class:`.ProductFrame` for
+        the cases in which the local frame objects act on a sequential order of subsystems. In other
+        words, this method converts the sequence of frames to a dictionary of frames in accordance
+        with the input to :meth:`.ProductFrame.__init__` by using the positions along the sequence
+        as subsystem indices.
 
         Below are some examples:
 
-        .. code-block:: python
+        >>> from qiskit.quantum_info import Operator
+        >>> from povm_toolbox.quantum_info import SingleQubitPOVM, MultiQubitPOVM, ProductPOVM
 
-            sqp = SingleQubitPOVM([Operator.from_label("0"), Operator.from_label("1")])
-            product = ProductPOVM.from_list([sqp, sqp])
-            # is equivalent to
-            product = ProductPOVM({(0,): sqp, (1,): sqp})
+        >>> sqp = SingleQubitPOVM([Operator.from_label("0"), Operator.from_label("1")])
+        >>> product = ProductPOVM.from_list([sqp, sqp])
+        >>> # is equivalent to
+        >>> product = ProductPOVM({(0,): sqp, (1,): sqp})
 
-            mqp = MultiQubitFrame(
-                [
-                    Operator.from_label("00"),
-                    Operator.from_label("01"),
-                    Operator.from_label("10"),
-                    Operator.from_label("11"),
-                ]
-            )
-            product = ProductPOVM.from_list([mqp, mqp])
-            # is equivalent to
-            product = ProductPOVM({(0, 1): mqp, (2, 3): mqp})
+        >>> mqp = MultiQubitPOVM(
+        ...     [
+        ...         Operator.from_label("00"),
+        ...         Operator.from_label("01"),
+        ...         Operator.from_label("10"),
+        ...         Operator.from_label("11"),
+        ...     ]
+        ... )
+        >>> product = ProductPOVM.from_list([mqp, mqp])
+        >>> # is equivalent to
+        >>> product = ProductPOVM({(0, 1): mqp, (2, 3): mqp})
 
-            product = ProductPOVM.from_list([sqp, sqp, mqp])
-            # is equivalent to
-            product = ProductPOVM({(0,): sqp, (1,): sqp, (2, 3): mqp})
+        >>> product = ProductPOVM.from_list([sqp, sqp, mqp])
+        >>> # is equivalent to
+        >>> product = ProductPOVM({(0,): sqp, (1,): sqp, (2, 3): mqp})
 
-            product = ProductPOVM.from_list([sqp, mqp, sqp])
-            # is equivalent to
-            product = ProductPOVM({(0,): sqp, (1, 2): mqp, (3,): sqp})
+        >>> product = ProductPOVM.from_list([sqp, mqp, sqp])
+        >>> # is equivalent to
+        >>> product = ProductPOVM({(0,): sqp, (1, 2): mqp, (3,): sqp})
 
         Args:
-            povms: a sequence of :class:`.MultiQubitFrame` objects.
+            frames: a sequence of :class:`.MultiQubitFrame` objects.
 
         Returns:
-            A new :class:`.ProductPOVM` instance.
+            A new :class:`.ProductFrame` instance.
         """
-        povm_dict = {}
+        frame_dict = {}
         idx = 0
-        for povm in povms:
+        for frame in frames:
             prev_idx = idx
-            idx += povm.num_subsystems
-            povm_dict[tuple(range(prev_idx, idx))] = povm
-        return cls(povm_dict)
+            idx += frame.num_subsystems
+            frame_dict[tuple(range(prev_idx, idx))] = frame
+        return cls(frame_dict)
 
     @property
     def informationally_complete(self) -> bool:
-        """Return if the frame spans the entire Hilbert space."""
         return self._informationally_complete
 
     @property
     def dimension(self) -> int:
-        """Give the dimension of the Hilbert space on which the effects act."""
         return self._dimension
 
     @property
     def num_operators(self) -> int:
-        """Give the number of single-qubit operators forming the POVM."""
         return self._num_operators
 
     @property
@@ -176,15 +182,15 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
     @property
     def sub_systems(self) -> list[tuple[int, ...]]:
         """Give the number of operators per sub-system."""
-        return list(self._povms.keys())
+        return list(self._frames.keys())
 
     def _check_validity(self) -> None:
-        """Check if POVM axioms are fulfilled.
+        """Check if frame axioms are fulfilled for all local frames.
 
-        Raises:
-            TODO.
+        .. note::
+           This raises whatever errors the local frames' methods may raise.
         """
-        for povm in self._povms.values():
+        for povm in self._frames.values():
             povm._check_validity()
 
     def __getitem__(self, sub_system: tuple[int, ...]) -> T:
@@ -196,10 +202,10 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
         Returns:
             The :class:`.MultiQubitFrame` acting on the specified sub-system.
         """
-        return self._povms[sub_system]
+        return self._frames[sub_system]
 
     def __len__(self) -> int:
-        """Return the number of outcomes of the POVM."""
+        """Return the number of outcomes of the product frame."""
         return self.num_operators
 
     def _trace_of_prod(self, operator: SparsePauliOp, frame_op_idx: tuple[int, ...]) -> float:
@@ -207,8 +213,8 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
 
         Args:
             operator: the input operator to multiply with a frame operator.
-            frame_op_idx: the label specifying the frame operator to use. The frame operator is labeled
-                by a tuple of integers (one index per local frame).
+            frame_op_idx: the label specifying the frame operator to use. The frame operator is
+                labeled by a tuple of integers (one index per local frame).
 
         Returns:
             The trace of the product of the input operator with the specified frame operator.
@@ -216,7 +222,8 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
         Raises:
             IndexError: when the provided outcome label (tuple of integers) has a number of integers
                 which does not correspond to the number of local frames making up the product frame.
-            IndexError: when a local index exceed the number of operators of the corresponding local frame.
+            IndexError: when a local index exceeds the number of operators of the corresponding
+                local frame.
             ValueError: when the output is not a real number.
         """
         p_idx = 0.0 + 0.0j
@@ -229,7 +236,7 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
             #     of the high-dimensional array ``p_init`` along which this local POVM is encoded.
             #   - ``idx`` are the qubit indices on which this local POVM acts.
             #   - ``povm`` is the actual local POVM object.
-            for j, (idx, povm) in enumerate(self._povms.items()):
+            for j, (idx, povm) in enumerate(self._frames.items()):
                 # Extract the local Pauli term on the qubit indices of this local POVM.
                 sublabel = "".join(label[-(i + 1)] for i in idx)
                 # Try to obtain the coefficient of the local POVM for this local Pauli term.
@@ -244,13 +251,15 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
                 except IndexError as exc:
                     if len(frame_op_idx) <= j:
                         raise IndexError(
-                            f"The outcome label {frame_op_idx} does not match the expected shape. It is"
-                            f" supposed to contain {len(self._povms)} integers, but has {len(frame_op_idx)}."
+                            f"The outcome label {frame_op_idx} does not match the expected shape. "
+                            f"It is supposed to contain {len(self._frames)} integers, but has "
+                            f"{len(frame_op_idx)}."
                         ) from exc
                     if povm.num_operators <= frame_op_idx[j]:
                         raise IndexError(
                             f"Outcome index '{frame_op_idx[j]}' is out of range for the local POVM"
-                            f" acting on subsystems {idx}. This POVM has {povm.num_operators} outcomes."
+                            f" acting on subsystems {idx}. This POVM has {povm.num_operators}"
+                            "outcomes."
                         ) from exc
                     raise exc
                 else:
@@ -269,7 +278,10 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
         hermitian_op: SparsePauliOp | Operator,
         frame_op_idx: tuple[int, ...] | set[tuple[int, ...]] | None = None,
     ) -> float | dict[tuple[int, ...], float] | np.ndarray:
-        """TODO.
+        """Return the frame coefficients of ``hermitian_op``.
+
+        .. note::
+           TODO: align this docstring with that of :class:`.BaseFrame`.
 
         Args:
             hermitian_op: TODO.

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -36,9 +36,9 @@ T = TypeVar("T", bound=MultiQubitFrame)
 class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
     r"""Class to represent a set of product frame operators.
 
-    A product frame :math:`M` is made of local frames :math:`M_1, M2, ...` acting on respective
+    A product frame :math:`M` is made of local frames :math:`M1, M2, ...` acting on respective
     subsystems. Each global operator can be written as the tensor product of local operators,
-    :math:`M_{k_1, k_2, ...} = M1_{k_1} \otimes M2_{k2} \otimes \ldots`.
+    :math:`M_{k_1, k_2, ...} = M1_{k_1} \otimes M2_{k_2} \otimes \ldots`.
 
     .. note::
        This is a base class which collects functionality common to various subclasses. As an

--- a/povm_toolbox/quantum_info/product_povm.py
+++ b/povm_toolbox/quantum_info/product_povm.py
@@ -42,7 +42,7 @@ class ProductPOVM(ProductFrame[MultiQubitPOVM], BasePOVM):
         Raises:
             TODO.
         """
-        for povm in self._povms.values():
+        for povm in self._frames.values():
             if not isinstance(povm, MultiQubitPOVM):
                 raise TypeError
             povm._check_validity()

--- a/povm_toolbox/quantum_info/product_povm.py
+++ b/povm_toolbox/quantum_info/product_povm.py
@@ -12,18 +12,10 @@
 
 from __future__ import annotations
 
-import sys
-
-if sys.version_info < (3, 12):
-    from typing_extensions import override
-else:
-    from typing import override
-
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
-from qiskit.quantum_info import DensityMatrix, SparsePauliOp, Statevector
 from qiskit.visualization.utils import matplotlib_close_if_inline
 
 from .base import BasePOVM
@@ -76,16 +68,6 @@ class ProductPOVM(ProductFrame[MultiQubitPOVM], BasePOVM):
                     f" of type `{type(povm)}` instead."
                 )
             povm._check_validity()
-
-    @override
-    def get_prob(
-        self,
-        rho: SparsePauliOp | DensityMatrix | Statevector,
-        outcome_idx: tuple[int, ...] | set[tuple[int, ...]] | None = None,
-    ) -> float | dict[tuple[int, ...], float] | np.ndarray:
-        if not isinstance(rho, SparsePauliOp):
-            rho = SparsePauliOp.from_operator(rho)
-        return self.analysis(rho, outcome_idx)
 
     def draw_bloch(
         self,

--- a/povm_toolbox/quantum_info/product_povm.py
+++ b/povm_toolbox/quantum_info/product_povm.py
@@ -28,9 +28,9 @@ from .product_frame import ProductFrame
 class ProductPOVM(ProductFrame[MultiQubitPOVM], BasePOVM):
     r"""Class to represent a set of product POVM operators.
 
-    A product POVM :math:`M` is made of local POVMs :math:`M_1, M2, ...` acting on respective
+    A product POVM :math:`M` is made of local POVMs :math:`M1, M2, ...` acting on respective
     subsystems. Each global effect can be written as the tensor product of local effects,
-    :math:`M_{k_1, k_2, ...} = M1_{k_1} \otimes M2_{k2} \otimes \ldots`.
+    :math:`M_{k_1, k_2, ...} = M1_{k_1} \otimes M2_{k_2} \otimes \ldots`.
 
     Below is an example of how to construct an instance of this class.
 

--- a/povm_toolbox/quantum_info/product_povm.py
+++ b/povm_toolbox/quantum_info/product_povm.py
@@ -12,6 +12,13 @@
 
 from __future__ import annotations
 
+import sys
+
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
@@ -30,7 +37,7 @@ class ProductPOVM(ProductFrame[MultiQubitPOVM], BasePOVM):
 
     A product POVM :math:`M` is made of local POVMs :math:`M1, M2, ...` acting on respective
     subsystems. Each global effect can be written as the tensor product of local effects,
-    :math:`M_{k_1, k_2, ...} = M1_{k_1} \otimes M2_{k_2} \otimes \ldots`.
+    :math:`M_{k_1, k_2, ...} = M1_{k_1} \otimes M2_{k_2} \otimes \cdots`.
 
     Below is an example of how to construct an instance of this class.
 
@@ -70,30 +77,12 @@ class ProductPOVM(ProductFrame[MultiQubitPOVM], BasePOVM):
                 )
             povm._check_validity()
 
+    @override
     def get_prob(
         self,
         rho: SparsePauliOp | DensityMatrix | Statevector,
         outcome_idx: tuple[int, ...] | set[tuple[int, ...]] | None = None,
     ) -> float | dict[tuple[int, ...], float] | np.ndarray:
-        """Return the outcome probabilities given a state rho.
-
-        .. note::
-           TODO: align this docstring with that of :class:`.BasePOVM`.
-
-        Args:
-            rho: the input state over which to compute the outcome probabilities.
-            outcome_idx: the outcomes for which one queries the probability. Each outcome is labeled
-                by a tuple of integers (one index per local POVM). One can query a single outcome or a
-                set of outcomes. If ``None``, all outcomes are queried.
-
-        Returns:
-            Probabilities of obtaining the outcome(s) specified by ``outcome_idx`` over the state ``rho``.
-            If a specific outcome was queried, a ``float`` is returned. If a specific set of outcomes was
-            queried, a dictionary mapping outcomes to probabilities is returned. If all outcomes were
-            queried, a high-dimensional array with one dimension per local POVM stored inside this
-            :class:`.`ProductPOVM` is returned. The length of each dimension is given by the number of outcomes
-            of the POVM encoded along that axis.
-        """
         if not isinstance(rho, SparsePauliOp):
             rho = SparsePauliOp.from_operator(rho)
         return self.analysis(rho, outcome_idx)

--- a/povm_toolbox/quantum_info/single_qubit_povm.py
+++ b/povm_toolbox/quantum_info/single_qubit_povm.py
@@ -24,6 +24,24 @@ from .multi_qubit_povm import MultiQubitPOVM
 
 class SingleQubitPOVM(MultiQubitPOVM):
     """A convenience class to represent a single-qubit :class:`.MultiQubitPOVM` instance.
+
+    Below is a simple example showing how you define a symmetric and informationally-complete POVM
+    (SIC-POVM):
+
+    >>> import cmath
+    >>> import numpy as np
+    >>> from povm_toolbox.quantum_info import SingleQubitPOVM
+    >>> vecs = np.sqrt(1.0 / 2.0) * np.array(
+    ...     [
+    ...         [1, 0],
+    ...         [np.sqrt(1.0 / 3.0), np.sqrt(2.0 / 3.0)],
+    ...         [np.sqrt(1.0 / 3.0), np.sqrt(2.0 / 3.0) * cmath.exp(2.0j * np.pi / 3)],
+    ...         [np.sqrt(1.0 / 3.0), np.sqrt(2.0 / 3.0) * cmath.exp(4.0j * np.pi / 3)],
+    ...     ]
+    ... )
+    >>> sic_povm = SingleQubitPOVM.from_vectors(vecs)
+    >>> print(sic_povm)
+    SingleQubitPOVM<4> at 0x...
     """
 
     def _check_validity(self) -> None:
@@ -53,6 +71,27 @@ class SingleQubitPOVM(MultiQubitPOVM):
         where :math:`\vec{\sigma}` is the usual Pauli vector and :math:`||\vec{a}_k||^2=1`.
         We then define the Bloch vector of a rank-1 effect as
         :math:`\vec{r}_k = \gamma_k \vec{a}_k`, which uniquely defines the rank-1 effect.
+
+        Example:
+
+        >>> import cmath
+        >>> import numpy as np
+        >>> from povm_toolbox.quantum_info import SingleQubitPOVM
+        >>> vecs = np.sqrt(1.0 / 2.0) * np.array(
+        ...     [
+        ...         [1, 0],
+        ...         [np.sqrt(1.0 / 3.0), np.sqrt(2.0 / 3.0)],
+        ...         [np.sqrt(1.0 / 3.0), np.sqrt(2.0 / 3.0) * cmath.exp(2.0j * np.pi / 3)],
+        ...         [np.sqrt(1.0 / 3.0), np.sqrt(2.0 / 3.0) * cmath.exp(4.0j * np.pi / 3)],
+        ...     ]
+        ... )
+        >>> sic_povm = SingleQubitPOVM.from_vectors(vecs)
+        >>> bloch_vectors = sic_povm.get_bloch_vectors()
+        >>> print(bloch_vectors)  # doctest: +FLOAT_CMP
+        [[ 0.          0.          0.5       ]
+         [ 0.47140452  0.         -0.16666667]
+         [-0.23570226  0.40824829 -0.16666667]
+         [-0.23570226 -0.40824829 -0.16666667]]
 
         Returns:
             The Bloch vector of all POVM effects.
@@ -85,6 +124,24 @@ class SingleQubitPOVM(MultiQubitPOVM):
         colorbar: bool = False,
     ) -> Figure:
         """Plot the Bloch vector of each effect of the POVM.
+
+        .. plot::
+           :include-source:
+
+           >>> import cmath
+           >>> import numpy as np
+           >>> from povm_toolbox.quantum_info import SingleQubitPOVM
+           >>> vecs = np.sqrt(1.0 / 2.0) * np.array(
+           ...     [
+           ...         [1, 0],
+           ...         [np.sqrt(1.0 / 3.0), np.sqrt(2.0 / 3.0)],
+           ...         [np.sqrt(1.0 / 3.0), np.sqrt(2.0 / 3.0) * cmath.exp(2.0j * np.pi / 3)],
+           ...         [np.sqrt(1.0 / 3.0), np.sqrt(2.0 / 3.0) * cmath.exp(4.0j * np.pi / 3)],
+           ...     ]
+           ... )
+           >>> sic_povm = SingleQubitPOVM.from_vectors(vecs)
+           >>> sic_povm.draw_bloch()
+           <Figure size 500x500 with 1 Axes>
 
         Args:
             title: A string that represents the plot title.

--- a/povm_toolbox/quantum_info/single_qubit_povm.py
+++ b/povm_toolbox/quantum_info/single_qubit_povm.py
@@ -8,7 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TODO."""
+"""SingleQubitPOVM."""
 
 from __future__ import annotations
 
@@ -23,13 +23,16 @@ from .multi_qubit_povm import MultiQubitPOVM
 
 
 class SingleQubitPOVM(MultiQubitPOVM):
-    """Class to represent a set of IC single-qubit POVM operators."""
+    """A convenience class to represent a single-qubit :class:`.MultiQubitPOVM` instance.
+    """
 
     def _check_validity(self) -> None:
-        """TODO.
+        """Check if POVM axioms are fulfilled.
+
+        In addition to the checks performed by the super-class, the following errors may be raised.
 
         Raises:
-            ValueError: TODO.
+            ValueError: if the dimension does not equal 2 (i.e. the POVM acts on more than 1 qubit).
         """
         if not self.dimension == 2:
             raise ValueError(
@@ -47,10 +50,15 @@ class SingleQubitPOVM(MultiQubitPOVM):
             M_k = \gamma_k |\psi_k \rangle \langle \psi_k | = \gamma_k
             \frac{1}{2} \left( \mathbb{I} + \vec{a}_k \cdot \vec{\sigma} \right)
 
-        where :math:`\vec{\sigma}` is the usual Pauli vector and
-        :math:`||\vec{a}_k||^2=1`. We then define the Bloch vector of a rank-1
-        effect as :math:`\vec{r}_k = \gamma_k \vec{a}_k`, which uniquely defines
-        the rank-1 effect.
+        where :math:`\vec{\sigma}` is the usual Pauli vector and :math:`||\vec{a}_k||^2=1`.
+        We then define the Bloch vector of a rank-1 effect as
+        :math:`\vec{r}_k = \gamma_k \vec{a}_k`, which uniquely defines the rank-1 effect.
+
+        Returns:
+            The Bloch vector of all POVM effects.
+
+        Raises:
+            ValueError: if any effect of this POVM has a rank greater than 1.
         """
         r = np.empty((self.num_outcomes, 3))
         for i, pauli_op in enumerate(self.pauli_operators):
@@ -87,6 +95,9 @@ class SingleQubitPOVM(MultiQubitPOVM):
             colorbar: If ``True``, normalize the vectors on the Bloch sphere and
                 add a colormap to keep track of the norm of the vectors. It can
                 help to visualize the vector if they have a small norm.
+
+        Returns:
+            The resulting figure.
         """
         if figsize is None:
             figsize = (5, 4) if colorbar else (5, 5)

--- a/test/library/test_classical_shadows.py
+++ b/test/library/test_classical_shadows.py
@@ -56,6 +56,6 @@ class TestClassicalShadows(TestCase):
             self.assertEqual(num_qubits, cs_implementation.num_qubits)
             cs_povm = cs_implementation.definition()
             for i in range(num_qubits):
-                self.assertEqual(cs_povm._povms[(i,)].num_outcomes, sqpovm.num_outcomes)
+                self.assertEqual(cs_povm._frames[(i,)].num_outcomes, sqpovm.num_outcomes)
                 for k in range(sqpovm.num_outcomes):
-                    self.assertAlmostEqual(cs_povm._povms[(i,)][k], sqpovm[k])
+                    self.assertAlmostEqual(cs_povm._frames[(i,)][k], sqpovm[k])

--- a/test/library/test_locally_biased_classical_shadows.py
+++ b/test/library/test_locally_biased_classical_shadows.py
@@ -57,6 +57,6 @@ class TestRandomizedPMs(TestCase):
                         q[i, 2] * Operator.from_label("l"),
                     ]
                 )
-                self.assertEqual(cs_povm._povms[(i,)].num_outcomes, sqpovm.num_outcomes)
+                self.assertEqual(cs_povm._frames[(i,)].num_outcomes, sqpovm.num_outcomes)
                 for k in range(sqpovm.num_outcomes):
-                    self.assertTrue(np.allclose(cs_povm._povms[(i,)][k], sqpovm[k]))
+                    self.assertTrue(np.allclose(cs_povm._frames[(i,)][k], sqpovm[k]))

--- a/test/quantum_info/test_product_povm.py
+++ b/test/quantum_info/test_product_povm.py
@@ -103,19 +103,19 @@ class TestProductPOVM(TestCase):
         with self.subTest("SingleQubitPOVM objects"):
             expected = {(0,): sqp, (1,): sqp}
             product = ProductPOVM.from_list([sqp, sqp])
-            self.assertEqual(expected, product._povms)
+            self.assertEqual(expected, product._frames)
         with self.subTest("MultiQubitPOVM objects"):
             expected = {(0, 1): mqp, (2, 3): mqp}
             product = ProductPOVM.from_list([mqp, mqp])
-            self.assertEqual(expected, product._povms)
+            self.assertEqual(expected, product._frames)
         with self.subTest("SingleQubitPOVM + MultiQubitPOVM objects"):
             expected = {(0,): sqp, (1,): sqp, (2, 3): mqp}
             product = ProductPOVM.from_list([sqp, sqp, mqp])
-            self.assertEqual(expected, product._povms)
+            self.assertEqual(expected, product._frames)
         with self.subTest("SingleQubitPOVM + MultiQubitPOVM objects - interleaved"):
             expected = {(0,): sqp, (1, 2): mqp, (3,): sqp}
             product = ProductPOVM.from_list([sqp, mqp, sqp])
-            self.assertEqual(expected, product._povms)
+            self.assertEqual(expected, product._frames)
 
     def test_get_prob(self):
         """Test if we can build a LB Classical Shadow POVM from the generic class"""

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ basepython = python3.10
 extras =
   docs
 commands =
-  sphinx-build -j auto -W -T --keep-going -b html {posargs} {toxinidir}/docs/ {toxinidir}/docs/_build/html
+  sphinx-build -j auto -T --keep-going -b html {posargs} {toxinidir}/docs/ {toxinidir}/docs/_build/html
 
 [testenv:docs-clean]
 skip_install = true


### PR DESCRIPTION
This follows up on #48 and actually cleans up the documentation of the `quantum_info` submodule.