### PR TITLE
Improvements to test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,5 +31,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox coverage
       - name: Run coverage
+        env:
+          QISKIT_IBM_URL: ${{ secrets.QISKIT_IBM_URL }}
+          QISKIT_IBM_TOKEN: ${{ secrets.QISKIT_IBM_TOKEN }}
+          QISKIT_IBM_INSTANCE: ${{ secrets.QISKIT_IBM_INSTANCE }}
         run: |
           tox -e coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,5 +36,4 @@ jobs:
           QISKIT_IBM_TOKEN: ${{ secrets.QISKIT_IBM_TOKEN }}
           QISKIT_IBM_INSTANCE: ${{ secrets.QISKIT_IBM_INSTANCE }}
         run: |
-          echo "$QISKIT_IBM_URL"
           tox -e coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,4 +36,5 @@ jobs:
           QISKIT_IBM_TOKEN: ${{ secrets.QISKIT_IBM_TOKEN }}
           QISKIT_IBM_INSTANCE: ${{ secrets.QISKIT_IBM_INSTANCE }}
         run: |
+          echo "$QISKIT_IBM_URL"
           tox -e coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,10 @@ jobs:
           pip install tox
       - name: Test using tox environment
         shell: bash
+        env:
+          QISKIT_IBM_URL: ${{ secrets.QISKIT_IBM_URL }}
+          QISKIT_IBM_TOKEN: ${{ secrets.QISKIT_IBM_TOKEN }}
+          QISKIT_IBM_INSTANCE: ${{ secrets.QISKIT_IBM_INSTANCE }}
         run: |
           pver=${{ matrix.python-version }}
           tox -e py${pver/./}

--- a/povm_toolbox/library/povm_implementation.py
+++ b/povm_toolbox/library/povm_implementation.py
@@ -30,7 +30,7 @@ from qiskit.transpiler import StagedPassManager, TranspileLayout
 from povm_toolbox.quantum_info.base import BasePOVM
 
 if TYPE_CHECKING:
-    from .metadata import POVMMetadata
+    from .metadata import POVMMetadata  # pragma: no cover
 
 LOGGER = logging.getLogger(__name__)
 
@@ -87,7 +87,11 @@ class POVMImplementation(ABC, Generic[MetadataT]):
 
     def __repr__(self) -> str:
         """Return the string representation of a POVMImplementation instance."""
-        return f"{self.__class__.__name__}(num_qubits={self.num_qubits})"
+        # NOTE: this is not covered by tests because it is a fallback intended to give a meaningful
+        # representation for actual implementations of this interface which do not overwrite this
+        # function. However, all actual implementation in this library do overwrite this and, thus,
+        # this fallback is not executed during the test coverage.
+        return f"{self.__class__.__name__}(num_qubits={self.num_qubits})"  # pragma: no cover
 
     @abstractmethod
     def definition(self) -> BasePOVM:
@@ -156,8 +160,6 @@ class POVMImplementation(ABC, Generic[MetadataT]):
             elif isinstance(dest_circuit.layout, TranspileLayout):
                 # Extract the final layout of the transpiled circuit (ancillas are filtered).
                 index_layout = dest_circuit.layout.final_index_layout(filter_ancillas=True)
-            else:
-                raise NotImplementedError
         else:
             index_layout = self.measurement_layout
 

--- a/povm_toolbox/library/povm_implementation.py
+++ b/povm_toolbox/library/povm_implementation.py
@@ -25,7 +25,7 @@ from qiskit.primitives.containers import DataBin
 from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.primitives.containers.bit_array import BitArray
 from qiskit.primitives.containers.sampler_pub import SamplerPub
-from qiskit.transpiler import StagedPassManager, TranspileLayout
+from qiskit.transpiler import StagedPassManager
 
 from povm_toolbox.quantum_info.base import BasePOVM
 
@@ -156,8 +156,7 @@ class POVMImplementation(ABC, Generic[MetadataT]):
             if dest_circuit.layout is None:
                 # Basic one-to-one layout
                 index_layout = list(range(dest_circuit.num_qubits))
-
-            elif isinstance(dest_circuit.layout, TranspileLayout):
+            else:
                 # Extract the final layout of the transpiled circuit (ancillas are filtered).
                 index_layout = dest_circuit.layout.final_index_layout(filter_ancillas=True)
         else:

--- a/povm_toolbox/library/randomized_projective_measurements.py
+++ b/povm_toolbox/library/randomized_projective_measurements.py
@@ -307,40 +307,7 @@ class RandomizedProjectiveMeasurements(POVMImplementation[RPMMetadata]):
             binding_data[circuit_param] = np.tile(circuit_val[..., np.newaxis, :], (shots, 1))
 
         # We create the array that will store the qubit-wise indices of all the sampled PVMs.
-        pvm_idx = np.zeros((*circuit_binding.shape, shots, self.num_qubits), dtype=int)
-        # We loop over the different qubits :
-        for i in range(self.num_qubits):
-            # For each qubit, we sample PVMs according to the local bias defined on
-            # this particular qubit. We draw a PVM for each "shot" and for
-            # each set of circuit parameter values supplied by the user through the
-            # :method:``POVMSampler.run`` method.
-            pvm_idx[..., i] = self._rng.choice(
-                self._num_PVMs,
-                size=circuit_binding.size * shots,
-                replace=True,
-                p=self.bias[i],
-            ).reshape(  # Reshape to match the shape of ``pvm_idx``.
-                (*circuit_binding.shape, shots)
-            )
-            # If the twirling option is turned on we double the number of PVMs
-            # because each PVM can be twirled. The encoding works as follows :
-            #   `pvm_idx % self._num_PVMs` is the index of the PVM used and
-            #   `pvm_idx // self._num_PVMs` indicates if the PVM has been twirled.
-            # For the example of :class:`ClassicalShadows`, we have:
-            #   num_PVMs = 3
-            #   pvm_idx == 0 -> untwirled Z-measurement: {|0><0|, |1><1|}
-            #   pvm_idx == 1 -> untwirled X-measurement: {|+><+|, |-><-|}
-            #   pvm_idx == 2 -> untwirled Y-measurement: {|+i><+i|, |-i><-i|}
-            #   pvm_idx == 3 -> twirled Z-measurement: {|1><1|, |0><0|}
-            #   pvm_idx == 4 -> twirled X-measurement: {|-><-|, |+><+|}
-            #   pvm_idx == 5 -> twirled Y-measurement: {|-i><-i|, |+i><+i|}
-            if self.measurement_twirl:
-                pvm_idx[..., i] += self._num_PVMs * self._rng.integers(
-                    2,
-                    size=circuit_binding.size * shots,
-                ).reshape(  # Reshape to match the shape of ``pvm_idx``.
-                    (*circuit_binding.shape, shots)
-                )
+        pvm_idx = self._sample_pvm_idxs(circuit_binding, shots)
 
         # Transform the PVM indices into actual measurement parameters that are
         # then coerced into a :class:``BindingsArray`` object.
@@ -449,6 +416,54 @@ class RandomizedProjectiveMeasurements(POVMImplementation[RPMMetadata]):
         LOGGER.info(f"Finished creating POVM outcomes. Took {t2 - t1:.6f}s")
 
         return povm_outcomes
+
+    def _sample_pvm_idxs(self, circuit_binding: BindingsArray, shots: int) -> np.ndarray:
+        """Sample the qubit-wise indices of PVMs to use for all shots.
+
+        Args:
+            circuit_binding: A bindings array.
+            shots: A specific number of shots to run with.
+
+        Returns:
+            The sampled PVM indices.
+        """
+        # We create the array that will store the qubit-wise indices of all the sampled PVMs.
+        pvm_idx = np.zeros((*circuit_binding.shape, shots, self.num_qubits), dtype=int)
+        # We loop over the different qubits :
+        for i in range(self.num_qubits):
+            # For each qubit, we sample PVMs according to the local bias defined on
+            # this particular qubit. We draw a PVM for each "shot" and for
+            # each set of circuit parameter values supplied by the user through the
+            # :method:``POVMSampler.run`` method.
+            pvm_idx[..., i] = self._rng.choice(
+                self._num_PVMs,
+                size=circuit_binding.size * shots,
+                replace=True,
+                p=self.bias[i],
+            ).reshape(  # Reshape to match the shape of ``pvm_idx``.
+                (*circuit_binding.shape, shots)
+            )
+            # If the twirling option is turned on we double the number of PVMs
+            # because each PVM can be twirled. The encoding works as follows :
+            #   `pvm_idx % self._num_PVMs` is the index of the PVM used and
+            #   `pvm_idx // self._num_PVMs` indicates if the PVM has been twirled.
+            # For the example of :class:`ClassicalShadows`, we have:
+            #   num_PVMs = 3
+            #   pvm_idx == 0 -> untwirled Z-measurement: {|0><0|, |1><1|}
+            #   pvm_idx == 1 -> untwirled X-measurement: {|+><+|, |-><-|}
+            #   pvm_idx == 2 -> untwirled Y-measurement: {|+i><+i|, |-i><-i|}
+            #   pvm_idx == 3 -> twirled Z-measurement: {|1><1|, |0><0|}
+            #   pvm_idx == 4 -> twirled X-measurement: {|-><-|, |+><+|}
+            #   pvm_idx == 5 -> twirled Y-measurement: {|-i><-i|, |+i><+i|}
+            if self.measurement_twirl:
+                pvm_idx[..., i] += self._num_PVMs * self._rng.integers(
+                    2,
+                    size=circuit_binding.size * shots,
+                ).reshape(  # Reshape to match the shape of ``pvm_idx``.
+                    (*circuit_binding.shape, shots)
+                )
+
+        return pvm_idx
 
     def _get_pvm_bindings_array(self, pvm_idx: np.ndarray) -> BindingsArray:
         """Return the concrete parameter values associated to a PVM label.

--- a/povm_toolbox/library/randomized_projective_measurements.py
+++ b/povm_toolbox/library/randomized_projective_measurements.py
@@ -19,7 +19,7 @@ import time
 if sys.version_info < (3, 12):
     from typing_extensions import override
 else:
-    from typing import override
+    from typing import override  # pragma: no cover
 
 import numpy as np
 from numpy.random import Generator, default_rng

--- a/povm_toolbox/quantum_info/multi_qubit_dual.py
+++ b/povm_toolbox/quantum_info/multi_qubit_dual.py
@@ -17,7 +17,7 @@ import sys
 if sys.version_info < (3, 12):
     from typing_extensions import override
 else:
-    from typing import override
+    from typing import override  # pragma: no cover
 
 import numpy as np
 from qiskit.quantum_info import Operator

--- a/povm_toolbox/quantum_info/multi_qubit_frame.py
+++ b/povm_toolbox/quantum_info/multi_qubit_frame.py
@@ -17,12 +17,12 @@ import sys
 if sys.version_info < (3, 11):
     from typing_extensions import Self
 else:
-    from typing import Self
+    from typing import Self  # pragma: no cover
 
 if sys.version_info < (3, 12):
     from typing_extensions import override
 else:
-    from typing import override
+    from typing import override  # pragma: no cover
 
 import numpy as np
 from qiskit.exceptions import QiskitError

--- a/povm_toolbox/quantum_info/product_dual.py
+++ b/povm_toolbox/quantum_info/product_dual.py
@@ -17,7 +17,7 @@ import sys
 if sys.version_info < (3, 12):
     from typing_extensions import override
 else:
-    from typing import override
+    from typing import override  # pragma: no cover
 
 from .base import BaseDual, BaseFrame
 from .multi_qubit_dual import MultiQubitDual

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -21,12 +21,12 @@ from typing import Generic, TypeVar
 if sys.version_info < (3, 11):
     from typing_extensions import Self
 else:
-    from typing import Self
+    from typing import Self  # pragma: no cover
 
 if sys.version_info < (3, 12):
     from typing_extensions import override
 else:
-    from typing import override
+    from typing import override  # pragma: no cover
 
 
 import numpy as np

--- a/povm_toolbox/sampler/povm_sampler_job.py
+++ b/povm_toolbox/sampler/povm_sampler_job.py
@@ -141,6 +141,8 @@ class POVMSamplerJob(BasePrimitiveJob[POVMPubResult, JobStatus]):
         cls,
         filename: str,
         base_job: BasePrimitiveJob | None = None,
+        *,
+        service: QiskitRuntimeService | None = None,
     ) -> POVMSamplerJob:
         """Recover a :class:`.POVMSamplerJob` instance.
 
@@ -153,6 +155,9 @@ class POVMSamplerJob(BasePrimitiveJob[POVMPubResult, JobStatus]):
                 stored inside the original :class:`.POVMSamplerJob` object. If ``None``, the
                 internal job ID stored in the metadata will be used to recover the internal job from
                 the :class:`~qiskit_ibm_runtime.qiskit_runtime_service.QiskitRuntimeService`.
+            service: an optional instance of the :class:`.QiskitRuntimeService`. If ``None``, an
+                instance will be generated with no arguments, resulting in it extracting the saved
+                configuration from disk.
 
         Raises:
             ValueError : if a ``base_job`` is supplied and its ID does not match with the ID stored
@@ -165,8 +170,9 @@ class POVMSamplerJob(BasePrimitiveJob[POVMPubResult, JobStatus]):
         job_id, metadata = cls._load_metadata(filename)
 
         if base_job is None:
-            # Use Qiskit Runtime Service to recover the ``BasePrimitiveJob``:
-            service = QiskitRuntimeService()
+            if service is None:  # pragma: no cover
+                # Use Qiskit Runtime Service to recover the ``BasePrimitiveJob``:
+                service = QiskitRuntimeService()  # pragma: no cover
             # Load the ``BasePrimitiveJob`` object:
             base_job = service.job(job_id)
         elif base_job.job_id() != job_id:

--- a/povm_toolbox/sampler/povm_sampler_job.py
+++ b/povm_toolbox/sampler/povm_sampler_job.py
@@ -21,7 +21,7 @@ import uuid
 if sys.version_info < (3, 12):
     from typing_extensions import override
 else:
-    from typing import override
+    from typing import override  # pragma: no cover
 
 from qiskit.primitives import BasePrimitiveJob, PrimitiveResult
 from qiskit.providers import JobStatus

--- a/test/library/test_povm_implementation.py
+++ b/test/library/test_povm_implementation.py
@@ -12,18 +12,19 @@
 
 from unittest import TestCase
 
-import numpy as np
-from povm_toolbox.library import ClassicalShadows, RandomizedProjectiveMeasurements
+from povm_toolbox.library import ClassicalShadows
 from qiskit.circuit import ClassicalRegister, QuantumCircuit
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.converters import circuit_to_dag
 from qiskit.primitives import StatevectorSampler
+from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 
 class TestPOVMImplementation(TestCase):
-    def __init__(self, methodName: str = "runTest") -> None:
-        super().__init__(methodName)
+    SEED = 42
+
+    def setUp(self) -> None:
         self.num_qubits = 3
         self.povm = ClassicalShadows(num_qubits=self.num_qubits)
 
@@ -84,51 +85,50 @@ class TestPOVMImplementation(TestCase):
     def test_composed_circuits(self):
         """Test the composition of the input circuit with the measurement circuit."""
 
+        sampler = StatevectorSampler(seed=self.SEED)
+
         with self.subTest("Composed circuit."):
-            # define a ZZX-measurement (inverse qubit order)
-            bias = np.array([1.0])
-            angles = np.array([[0.5 * np.pi, 0.0], [0.0, 0.0], [0.0, 0.0]])
-            pvm = RandomizedProjectiveMeasurements(num_qubits=3, bias=bias, angles=angles)
+            pvm = ClassicalShadows(3, seed=self.SEED)
 
             # compose circuits
             composed_circuit = pvm.compose_circuits(self.circuit)
-            parameter_values = pvm._get_pvm_bindings_array(np.array([[0, 0, 0]]))
-            sampler = StatevectorSampler()
-            job = sampler.run([(composed_circuit, parameter_values)])
 
-            # assert the final state is |+01>
-            self.assertTrue(
-                set(pvm._get_bitarray(job.result()[0].data).get_counts().keys()) == {"100"}
-            )
+            # obtain measurement parameter values
+            pvm_idx = pvm._sample_pvm_idxs(BindingsArray(), shots=128)
+            parameter_values = pvm._get_pvm_bindings_array(pvm_idx)
+
+            # sample composed circuit
+            job = sampler.run([(composed_circuit, parameter_values)], shots=1)
+            result = pvm._get_bitarray(job.result()[0].data)
+
+            # validate outcome
+            expected = {"101": 28, "110": 66, "111": 17, "100": 17}
+            self.assertEqual(result.get_counts(), expected)
 
         with self.subTest("Composed after transpilation of input circuit."):
             pm = generate_preset_pass_manager(optimization_level=0, initial_layout=[2, 0, 1])
             routed_circuit = pm.run(self.circuit)
 
-            # define a ZZX-measurement (inverse qubit order)
-            bias = np.array([1.0])
-            angles = np.array([[0.5 * np.pi, 0.0], [0.0, 0.0], [0.0, 0.0]])
-            pvm = RandomizedProjectiveMeasurements(num_qubits=3, bias=bias, angles=angles)
+            pvm = ClassicalShadows(3, seed=self.SEED)
 
-            # compose circuits after the input circuit has been transpiled
+            # compose circuits
             composed_circuit = pvm.compose_circuits(routed_circuit)
-            parameter_values = pvm._get_pvm_bindings_array(np.array([[0, 0, 0]]))
-            sampler = StatevectorSampler()
-            job = sampler.run([(composed_circuit, parameter_values)])
 
-            # assert the final state is |+01>
-            self.assertTrue(
-                set(pvm._get_bitarray(job.result()[0].data).get_counts().keys()) == {"100"}
-            )
+            # obtain measurement parameter values
+            pvm_idx = pvm._sample_pvm_idxs(BindingsArray(), shots=128)
+            parameter_values = pvm._get_pvm_bindings_array(pvm_idx)
+
+            # sample composed circuit
+            job = sampler.run([(composed_circuit, parameter_values)], shots=1)
+            result = pvm._get_bitarray(job.result()[0].data)
+
+            # validate outcome
+            expected = {"101": 68, "110": 26, "111": 17, "100": 17}
+            self.assertEqual(result.get_counts(), expected)
 
         with self.subTest("Using measurement_layout"):
-            # define a ZZX-measurement (inverse qubit order)
-            bias = np.array([1.0])
-            angles = np.array([[0.5 * np.pi, 0.0], [0.0, 0.0]])
             measurement_layout = [0, 2]
-            pvm = RandomizedProjectiveMeasurements(
-                num_qubits=2, bias=bias, angles=angles, measurement_layout=measurement_layout
-            )
+            pvm = ClassicalShadows(2, seed=self.SEED, measurement_layout=measurement_layout)
 
             # compose circuits
             composed_circuit = pvm.compose_circuits(self.circuit)
@@ -138,11 +138,14 @@ class TestPOVMImplementation(TestCase):
             dag = circuit_to_dag(composed_circuit)
             self.assertEqual(list(dag.idle_wires()), [composed_circuit.qubits[1]])
 
-            parameter_values = pvm._get_pvm_bindings_array(np.array([[0, 0]]))
-            sampler = StatevectorSampler()
-            job = sampler.run([(composed_circuit, parameter_values)])
+            # obtain measurement parameter values
+            pvm_idx = pvm._sample_pvm_idxs(BindingsArray(), shots=128)
+            parameter_values = pvm._get_pvm_bindings_array(pvm_idx)
 
-            # assert the final state is |+01>
-            self.assertTrue(
-                set(pvm._get_bitarray(job.result()[0].data).get_counts().keys()) == {"10"}
-            )
+            # sample composed circuit
+            job = sampler.run([(composed_circuit, parameter_values)], shots=1)
+            result = pvm._get_bitarray(job.result()[0].data)
+
+            # validate outcome
+            expected = {"10": 43, "11": 85}
+            self.assertEqual(result.get_counts(), expected)

--- a/test/post_processor/test_dual_from_marginal_probabilities.py
+++ b/test/post_processor/test_dual_from_marginal_probabilities.py
@@ -107,3 +107,10 @@ class TestDualFromMarginalProbabilities(TestCase):
             exp_value, std = post_processor.get_expectation_value(observable)
             self.assertAlmostEqual(exp_value, -2.431562926033147)
             self.assertAlmostEqual(std, 0.6951590669925843)
+
+        with self.subTest("Test threshold on marginal dual."):
+            post_processor.dual = dual_from_marginal_probabilities(
+                povm=post_processor.povm, state=Statevector(qc), threshold=1.0
+            )
+            self.assertAlmostEqual(exp_value, -2.4315629260331466)
+            self.assertAlmostEqual(std, 0.6951590669925845)

--- a/test/sampler/test_povm_pub_result.py
+++ b/test/sampler/test_povm_pub_result.py
@@ -17,6 +17,7 @@ import numpy as np
 from povm_toolbox.library import ClassicalShadows
 from povm_toolbox.sampler import POVMSampler
 from qiskit import QuantumCircuit, qpy
+from qiskit.circuit import Parameter
 from qiskit.primitives import StatevectorSampler as Sampler
 
 
@@ -35,24 +36,19 @@ class TestPostProcessor(TestCase):
         with open("test/sampler/random_circuits.qpy", "rb") as file:
             qc = qpy.load(file)[0]
 
+        param = Parameter("a")
+        qc.ry(param, 0)
+
         povm_sampler = POVMSampler(sampler=Sampler(seed=self.SEED))
         self.measurement = ClassicalShadows(num_qubits=2, seed=self.SEED)
 
-        job = povm_sampler.run([qc], shots=10, povm=self.measurement)
+        job = povm_sampler.run([(qc, [0.0, np.pi])], shots=10, povm=self.measurement)
         result = job.result()
         self.pub_result = result[0]
 
         self.samples_check = [
-            (4, 3),
-            (2, 5),
-            (4, 3),
-            (4, 5),
-            (0, 3),
-            (4, 1),
-            (4, 3),
-            (4, 1),
-            (1, 5),
-            (2, 3),
+            [(4, 5), (2, 3), (4, 5), (4, 5), (1, 5), (4, 1), (4, 3), (4, 1), (1, 1), (2, 5)],
+            [(3, 5), (4, 5), (2, 1), (4, 3), (2, 3), (0, 1), (2, 1), (1, 3), (4, 1), (3, 5)],
         ]
 
     def test_metadata(self):
@@ -68,16 +64,30 @@ class TestPostProcessor(TestCase):
                     metadata.pvm_keys
                     == np.array(
                         [
-                            [2, 1],
-                            [1, 2],
-                            [2, 1],
-                            [2, 2],
-                            [0, 1],
-                            [2, 0],
-                            [2, 1],
-                            [2, 0],
-                            [0, 2],
-                            [1, 1],
+                            [
+                                [2, 2],
+                                [1, 1],
+                                [2, 2],
+                                [2, 2],
+                                [0, 2],
+                                [2, 0],
+                                [2, 1],
+                                [2, 0],
+                                [0, 0],
+                                [1, 2],
+                            ],
+                            [
+                                [1, 2],
+                                [2, 2],
+                                [1, 0],
+                                [2, 1],
+                                [1, 1],
+                                [0, 0],
+                                [1, 0],
+                                [0, 1],
+                                [2, 0],
+                                [1, 2],
+                            ],
                         ]
                     )
                 )
@@ -85,10 +95,22 @@ class TestPostProcessor(TestCase):
 
     def test_get_counts(self):
         """Test that the ``get_counts`` method works correctly."""
-        counts = self.pub_result.get_counts()
-        self.assertEqual(counts, Counter(self.samples_check))
+        with self.subTest("No loc"):
+            counts = self.pub_result.get_counts()
+            self.assertEqual(counts[0], Counter(self.samples_check[0]))
+            self.assertEqual(counts[1], Counter(self.samples_check[1]))
+
+        with self.subTest("With loc"):
+            counts = self.pub_result.get_counts(loc=1)
+            self.assertEqual(counts, Counter(self.samples_check[1]))
 
     def test_get_samples(self):
         """Test that the ``get_samples`` method works correctly."""
-        samples = self.pub_result.get_samples()
-        self.assertSequenceEqual(samples, self.samples_check)
+        with self.subTest("No loc"):
+            samples = self.pub_result.get_samples()
+            self.assertSequenceEqual(samples[0], self.samples_check[0])
+            self.assertSequenceEqual(samples[1], self.samples_check[1])
+
+        with self.subTest("With loc"):
+            samples = self.pub_result.get_samples(loc=1)
+            self.assertSequenceEqual(samples, self.samples_check[1])

--- a/test/sampler/test_povm_sampler.py
+++ b/test/sampler/test_povm_sampler.py
@@ -23,8 +23,7 @@ from qiskit_aer.primitives import SamplerV2 as AerSampler
 class TestPOVMSampler(TestCase):
     """Tests for the ``POVMSampler`` class."""
 
-    def __init__(self, methodName: str = "runTest") -> None:
-        super().__init__(methodName)
+    def setUp(self) -> None:
         self.sampler = AerSampler()
 
     def test_initialization(self):

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,10 @@ extras =
   test
 commands =
   pytest {posargs}
+passenv =
+  QISKIT_IBM_URL
+  QISKIT_IBM_TOKEN
+  QISKIT_IBM_INSTANCE
 
 [testenv:style]
 extras =


### PR DESCRIPTION
This deals with some minor improvements to test coverage:

- some exclusions of "uncovered" lines
- [x] tests around `QiskitRuntimeService` (see also #49)
- [x] test `POVMImplementation.compose_circuit` when a `TranspileLayout` is present
- [x] test `POVMImplementation.compose_circuit` when `POVMImplementation.measurement_layout is not None`
- [x] test `POVMPubResult.get_counts` with non-trivial `loc`
- [x] test `POVMPubResult.get_samples` with non-trivial `loc`

The final part of #37 is to complete the test suite of the `quantum_info` module.
Ideally, we can get the test coverage close to 100% with this PR and the final steps of resolving #37.