### PR TITLE
refactor: extract the POVMImplementation.insert_barriers attribute

### DIFF
--- a/povm_toolbox/library/classical_shadows.py
+++ b/povm_toolbox/library/classical_shadows.py
@@ -46,6 +46,7 @@ class ClassicalShadows(LocallyBiasedClassicalShadows):
         measurement_layout: list[int] | None = None,  # TODO: add | Layout
         measurement_twirl: bool = False,
         shot_repetitions: int = 1,
+        insert_barriers: bool = False,
         seed: int | Generator | None = None,
     ) -> None:
         """Initialize a classical shadows POVM.
@@ -65,6 +66,8 @@ class ClassicalShadows(LocallyBiasedClassicalShadows):
                 times we repeat the measurement for each sampled PVM (default is 1). Therefore, the
                 effective total number of measurement shots is ``shots`` multiplied by
                 ``shot_repetitions``.
+            insert_barriers: whether to insert a barrier between the composed circuits. This is not
+                done by default but can prove useful when visualizing the composed circuit.
             seed: optional seed to fix the :class:`numpy.random.Generator` used to sample PVMs.
                 The user can also directly provide a random generator. If ``None``, a random seed
                 will be used.
@@ -76,6 +79,7 @@ class ClassicalShadows(LocallyBiasedClassicalShadows):
             measurement_twirl=measurement_twirl,
             measurement_layout=measurement_layout,
             shot_repetitions=shot_repetitions,
+            insert_barriers=insert_barriers,
             seed=seed,
         )
 

--- a/povm_toolbox/library/locally_biased_classical_shadows.py
+++ b/povm_toolbox/library/locally_biased_classical_shadows.py
@@ -48,6 +48,7 @@ class LocallyBiasedClassicalShadows(MutuallyUnbiasedBasesMeasurements):
         measurement_layout: list[int] | None = None,  # TODO: add | Layout
         measurement_twirl: bool = False,
         shot_repetitions: int = 1,
+        insert_barriers: bool = False,
         seed: int | Generator | None = None,
     ) -> None:
         """Initialize a locally-biased classical shadows POVM.
@@ -71,6 +72,8 @@ class LocallyBiasedClassicalShadows(MutuallyUnbiasedBasesMeasurements):
                 times we repeat the measurement for each sampled PVM (default is 1). Therefore, the
                 effective total number of measurement shots is ``shots`` multiplied by
                 ``shot_repetitions``.
+            insert_barriers: whether to insert a barrier between the composed circuits. This is not
+                done by default but can prove useful when visualizing the composed circuit.
             seed: optional seed to fix the :class:`numpy.random.Generator` used to sample PVMs.
                 The Z-,X-,Y-measurements are sampled according to the probability distribution(s)
                 specified by ``bias``. The user can also directly provide a random generator. If
@@ -85,6 +88,7 @@ class LocallyBiasedClassicalShadows(MutuallyUnbiasedBasesMeasurements):
             measurement_twirl=measurement_twirl,
             measurement_layout=measurement_layout,
             shot_repetitions=shot_repetitions,
+            insert_barriers=insert_barriers,
             seed=seed,
         )
 

--- a/povm_toolbox/library/mutually_unbiased_bases_measurements.py
+++ b/povm_toolbox/library/mutually_unbiased_bases_measurements.py
@@ -58,6 +58,7 @@ class MutuallyUnbiasedBasesMeasurements(RandomizedProjectiveMeasurements):
         measurement_layout: list[int] | None = None,  # TODO: add | Layout
         measurement_twirl: bool = False,
         shot_repetitions: int = 1,
+        insert_barriers: bool = False,
         seed: int | Generator | None = None,
     ) -> None:
         """Initialize a mutually-unbiased-bases (MUB) POVM.
@@ -91,6 +92,8 @@ class MutuallyUnbiasedBasesMeasurements(RandomizedProjectiveMeasurements):
                 times we repeat the measurement for each sampled PVM (default is 1). Therefore, the
                 effective total number of measurement shots is ``shots`` multiplied by
                 ``shot_repetitions``.
+            insert_barriers: whether to insert a barrier between the composed circuits. This is not
+                done by default but can prove useful when visualizing the composed circuit.
             seed: optional seed to fix the :class:`numpy.random.Generator` used to sample PVMs.
                 The MUB measurements are sampled according to the probability distribution(s)
                 specified by ``bias``. The user can also directly provide a random generator. If
@@ -130,6 +133,7 @@ class MutuallyUnbiasedBasesMeasurements(RandomizedProjectiveMeasurements):
             measurement_twirl=measurement_twirl,
             measurement_layout=measurement_layout,
             shot_repetitions=shot_repetitions,
+            insert_barriers=insert_barriers,
             seed=seed,
         )
 

--- a/povm_toolbox/library/randomized_projective_measurements.py
+++ b/povm_toolbox/library/randomized_projective_measurements.py
@@ -130,7 +130,9 @@ class RandomizedProjectiveMeasurements(POVMImplementation[RPMMetadata]):
             ValueError: If the shape of ``angles`` is not compatible with ``num_qubits``.
             TypeError: If the type of ``seed`` is not valid.
         """
-        super().__init__(num_qubits, measurement_layout=measurement_layout, insert_barriers=insert_barriers)
+        super().__init__(
+            num_qubits, measurement_layout=measurement_layout, insert_barriers=insert_barriers
+        )
 
         if 2 * bias.shape[-1] != angles.shape[-1]:
             raise ValueError(

--- a/povm_toolbox/library/randomized_projective_measurements.py
+++ b/povm_toolbox/library/randomized_projective_measurements.py
@@ -78,6 +78,7 @@ class RandomizedProjectiveMeasurements(POVMImplementation[RPMMetadata]):
         measurement_layout: list[int] | None = None,  # TODO: add | Layout
         measurement_twirl: bool = False,
         shot_repetitions: int = 1,
+        insert_barriers: bool = False,
         seed: int | Generator | None = None,
     ) -> None:
         # NOTE: If we extend this interface to support different number of effects for each qubit in
@@ -113,6 +114,8 @@ class RandomizedProjectiveMeasurements(POVMImplementation[RPMMetadata]):
                 times we repeat the measurement for each sampled PVM (default is 1). Therefore, the
                 effective total number of measurement shots is ``shots`` multiplied by
                 ``shot_repetitions``.
+            insert_barriers: whether to insert a barrier between the composed circuits. This is not
+                done by default but can prove useful when visualizing the composed circuit.
             seed: optional seed to fix the :class:`numpy.random.Generator` used to sample PVMs.
                 The PVMs are sampled according to the probability distribution(s) specified by
                 ``bias``. The user can also directly provide a random generator. If ``None``, a
@@ -127,7 +130,7 @@ class RandomizedProjectiveMeasurements(POVMImplementation[RPMMetadata]):
             ValueError: If the shape of ``angles`` is not compatible with ``num_qubits``.
             TypeError: If the type of ``seed`` is not valid.
         """
-        super().__init__(num_qubits, measurement_layout=measurement_layout)
+        super().__init__(num_qubits, measurement_layout=measurement_layout, insert_barriers=insert_barriers)
 
         if 2 * bias.shape[-1] != angles.shape[-1]:
             raise ValueError(

--- a/test/library/test_povm_implementation.py
+++ b/test/library/test_povm_implementation.py
@@ -181,9 +181,12 @@ class TestPOVMImplementation(TestCase):
 
         with self.subTest("Test the insert_barriers option"):
             pvm = ClassicalShadows(3, seed=self.SEED)
-
             composed_circuit = pvm.compose_circuits(self.circuit)
-            composed_circuit_with_barrier = pvm.compose_circuits(self.circuit, insert_barriers=True)
+            composed_circuit.assign_parameters([0, 0, 0, 0, 0, 0], inplace=True)
+
+            pvm_barriers = ClassicalShadows(3, seed=self.SEED, insert_barriers=True)
+            composed_circuit_with_barrier = pvm_barriers.compose_circuits(self.circuit)
+            composed_circuit_with_barrier.assign_parameters([0, 0, 0, 0, 0, 0], inplace=True)
 
             pm = PassManager([RemoveBarriers()])
 


### PR DESCRIPTION
I have realized the most often the circuit gets composed without the user being able to set the keyword argument of the `POVMImplementation.compose_circuits` method. Instead, this PR changes the recently introduced `insert_barriers` option of #70 to be an instance attribute on the `POVMImplementation` thereby giving the user full access to it.