### PR TITLE
[backport] fix: the code publishing workflow

### DIFF
--- a/.github/workflows/publish_code.yml
+++ b/.github/workflows/publish_code.yml
@@ -1,6 +1,7 @@
 name: Publish release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+*"
@@ -10,7 +11,6 @@ jobs:
   pypi:
     name: pypi
     runs-on: ubuntu-latest
-    needs: github
     steps:
       - name: Checkout tag
         uses: actions/checkout@v4


### PR DESCRIPTION
This fix also needs to be backported to the `stable/0.1` branch

See also #74 