### PR TITLE
Post-process the 0.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "povm_toolbox"
-version = "0.1.0"
+version = "0.2.0"
 readme = "README.md"
 license = {file = "LICENSE.txt"}
 


### PR DESCRIPTION
On the `main` branch (which is the development branch) we are now building the `0.2.0` release.
Thus, the version number needs to be updated accordingly.

This should _not_ be backported.
Once the `0.2.0` release actually nears, any release notes generated until then should be moved into `releasenotes/notes/0.2` and everything should be placed on a `stable/0.2` branch.
Afterwards, `main` will start developing `0.3.0` and so on.

This should obviously _not_ be backported to `stable/0.1`.