### PR TITLE
ci: automatically publish docs on tag creation

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -2,6 +2,9 @@ name: Publish Sphinx docs
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   build:


### PR DESCRIPTION
Just like we automatically publish our code to PyPI, this ensures that we also automatically publish the new docs.