### PR TITLE
meta: add a package description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "povm_toolbox"
 version = "0.2.0"
 readme = "README.md"
+description = "A toolbox for the implementation of positive operator-valued measures (POVMs)."
 license = {file = "LICENSE.txt"}
 
 classifiers = [


### PR DESCRIPTION
I noticed that the package does not show a description when searched on PyPI: https://pypi.org/search/?q=povm-toolbox

This should fix that.
I used the same description as on the Github landing page.