### PR TITLE
Bug fix

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -2,6 +2,9 @@ name: Publish Sphinx docs
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   build:

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -273,8 +273,8 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
                     raise exc
                 else:
                     # If the label does exist, we multiply the coefficient into our summand.
-                    # The factor 2*N_qubit comes from Tr[(P_1...P_N)^2] = 2*N.
-                    summand *= coeff * 2 * povm.num_subsystems
+                    # The factor 2^N_qubit comes from Tr[(P_1...P_N)^2] = 2^N.
+                    summand *= coeff * 2**povm.num_subsystems
 
             # Once we have finished computing our summand, we add it into ``p_init``.
             p_idx += summand

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "qiskit>=1.0",
     "qiskit-ibm-runtime>=0.24",
     "qiskit-aer>=0.14",
-    "matplotlib",
+    "matplotlib!=3.9.1.post1",
 ]
 
 [project.optional-dependencies]

--- a/releasenotes/notes/release_fix_trace_of_products-9bb81dfc2724ed1d.yaml
+++ b/releasenotes/notes/release_fix_trace_of_products-9bb81dfc2724ed1d.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixing a bug in the ``ProductFrame._trace_of_prod`` method. 
+    This method computes the trace of the product of two operators.
+    It requires at some point the value of ``Tr[(P_N)^2]`` where ``P_N`` is an ``N``-qubit Pauli string. 
+    The correct value of this trace is ``2^N`` but was previously set to ``2*N``. 
+    This release fixes this issue.
+    Note that this issue was only impacting ``MultiQubitFrame`` for ``num_qubit>=3`` or product of such frames.

--- a/test/quantum_info/test_product_frame.py
+++ b/test/quantum_info/test_product_frame.py
@@ -28,26 +28,32 @@ class TestProductFrame(TestCase):
 
         num_qubit_max = 4
 
-        for num_qubit in range(1, num_qubit_max+1):
-
-            frame_product = ProductFrame.from_list(frames=num_qubit*[frame_1_qubit])
+        for num_qubit in range(1, num_qubit_max + 1):
+            frame_product = ProductFrame.from_list(frames=num_qubit * [frame_1_qubit])
 
             product_paulis = []
             for idx in np.ndindex(frame_product.shape):
                 product_paulis.append("".join([paulis[i] for i in idx[::-1]]))
-            frame_n_qubit = MultiQubitFrame([Operator.from_label(label) for label in product_paulis])
+            frame_n_qubit = MultiQubitFrame(
+                [Operator.from_label(label) for label in product_paulis]
+            )
 
             for i, pauli_string in enumerate(product_paulis):
                 decomposition_weights_n_qubit = frame_n_qubit.analysis(SparsePauliOp(pauli_string))
-                decomposition_weights_product = frame_product.analysis(SparsePauliOp(pauli_string)).flatten()
+                decomposition_weights_product = frame_product.analysis(
+                    SparsePauliOp(pauli_string)
+                ).flatten()
                 check = np.zeros(len(product_paulis))
                 check[i] = 2**num_qubit
                 self.assertTrue(np.allclose(decomposition_weights_n_qubit, check))
                 self.assertTrue(np.allclose(decomposition_weights_product, check))
 
-            decomposition_weights_n_qubit = frame_n_qubit.analysis(SparsePauliOp(product_paulis, np.ones(len(product_paulis))))
-            decomposition_weights_product = frame_product.analysis(SparsePauliOp(product_paulis, np.ones(len(product_paulis)))).flatten()
+            decomposition_weights_n_qubit = frame_n_qubit.analysis(
+                SparsePauliOp(product_paulis, np.ones(len(product_paulis)))
+            )
+            decomposition_weights_product = frame_product.analysis(
+                SparsePauliOp(product_paulis, np.ones(len(product_paulis)))
+            ).flatten()
             check = np.ones(len(product_paulis)) * 2**num_qubit
             self.assertTrue(np.allclose(decomposition_weights_n_qubit, check))
             self.assertTrue(np.allclose(decomposition_weights_product, check))
-        

--- a/test/quantum_info/test_product_frame.py
+++ b/test/quantum_info/test_product_frame.py
@@ -1,0 +1,53 @@
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the ProductFrame class."""
+
+from unittest import TestCase
+
+import numpy as np
+from povm_toolbox.quantum_info.multi_qubit_frame import MultiQubitFrame
+from povm_toolbox.quantum_info.product_frame import ProductFrame
+from qiskit.quantum_info import Operator, SparsePauliOp
+
+
+class TestProductFrame(TestCase):
+    """Tests for the ``ProductFrame`` class."""
+
+    def test_analysis(self):
+        """Test that the ``analysis`` method works correctly."""
+        paulis = ["I", "X", "Y", "Z"]
+        frame_1_qubit = MultiQubitFrame([Operator.from_label(label) for label in paulis])
+
+        num_qubit_max = 4
+
+        for num_qubit in range(1, num_qubit_max+1):
+
+            frame_product = ProductFrame.from_list(frames=num_qubit*[frame_1_qubit])
+
+            product_paulis = []
+            for idx in np.ndindex(frame_product.shape):
+                product_paulis.append("".join([paulis[i] for i in idx[::-1]]))
+            frame_n_qubit = MultiQubitFrame([Operator.from_label(label) for label in product_paulis])
+
+            for i, pauli_string in enumerate(product_paulis):
+                decomposition_weights_n_qubit = frame_n_qubit.analysis(SparsePauliOp(pauli_string))
+                decomposition_weights_product = frame_product.analysis(SparsePauliOp(pauli_string)).flatten()
+                check = np.zeros(len(product_paulis))
+                check[i] = 2**num_qubit
+                self.assertTrue(np.allclose(decomposition_weights_n_qubit, check))
+                self.assertTrue(np.allclose(decomposition_weights_product, check))
+
+            decomposition_weights_n_qubit = frame_n_qubit.analysis(SparsePauliOp(product_paulis, np.ones(len(product_paulis))))
+            decomposition_weights_product = frame_product.analysis(SparsePauliOp(product_paulis, np.ones(len(product_paulis)))).flatten()
+            check = np.ones(len(product_paulis)) * 2**num_qubit
+            self.assertTrue(np.allclose(decomposition_weights_n_qubit, check))
+            self.assertTrue(np.allclose(decomposition_weights_product, check))
+        


### PR DESCRIPTION
In the `_trace_of_prod` method of the `ProductFrame` class, we had these lines :
```
# If the label does exist, we multiply the coefficient into our summand.
# The factor 2*N_qubit comes from Tr[(P_1...P_N)^2] = 2*N.
summand *= coeff * 2 * povm.num_subsystems
```
but actually the correct factor is `2^N_qubit`.