### PR TITLE
Introduce a optional shape for `MultiQubitFrame` objects

### DIFF
--- a/povm_toolbox/quantum_info/multi_qubit_dual.py
+++ b/povm_toolbox/quantum_info/multi_qubit_dual.py
@@ -25,11 +25,11 @@ from scipy.linalg import orth
 
 from povm_toolbox.utilities import double_ket_to_matrix
 
-from .base import BaseDual, BaseFrame
+from .base import BaseDual, BaseFrame, LabelT
 from .multi_qubit_frame import MultiQubitFrame
 
 
-class MultiQubitDual(MultiQubitFrame, BaseDual):
+class MultiQubitDual(MultiQubitFrame[LabelT], BaseDual):
     """Class that collects all information that any Dual over multiple qubits should specify.
 
     This is a representation of a dual frame. Its elements are specified as a list of
@@ -61,7 +61,9 @@ class MultiQubitDual(MultiQubitFrame, BaseDual):
         if isinstance(frame, MultiQubitFrame):
             # Set default values for alphas if none is provided.
             if alphas is None:
-                alphas = tuple(np.real(np.trace(frame_op.data)) for frame_op in frame.operators)
+                alphas = tuple(
+                    np.real(np.trace(frame_op.data)) for frame_op in frame.operators.values()
+                )
             # Check that the number of alpha-parameters match the number of operators
             # forming the ``frame``.
             elif len(alphas) != frame.num_operators:
@@ -100,7 +102,10 @@ class MultiQubitDual(MultiQubitFrame, BaseDual):
                 frame_array @ diag_trace,
             )
             # Convert dual operators from double-ket to operator representation.
-            dual_operators = [Operator(double_ket_to_matrix(op)) for op in dual_operators_array.T]
+            dual_operators = {
+                key: Operator(double_ket_to_matrix(op))
+                for key, op in zip(frame.operators.keys(), dual_operators_array.T)
+            }
 
             return cls(dual_operators)
 

--- a/povm_toolbox/quantum_info/multi_qubit_frame.py
+++ b/povm_toolbox/quantum_info/multi_qubit_frame.py
@@ -33,7 +33,7 @@ from povm_toolbox.utilities import matrix_to_double_ket
 from .base import BaseFrame
 
 
-class MultiQubitFrame(BaseFrame[int]):
+class MultiQubitFrame(BaseFrame):
     """Class that collects all information that any frame of multiple qubits should specify.
 
     This is a representation of an operator-valued vector space frame. The effects are specified as
@@ -45,12 +45,15 @@ class MultiQubitFrame(BaseFrame[int]):
        for more general information.
     """
 
-    def __init__(self, list_operators: list[Operator]) -> None:
+    def __init__(
+        self, list_operators: list[Operator], shape: tuple[int, ...] | None = None
+    ) -> None:
         """Initialize from explicit operators.
 
         Args:
             list_operators: list that contains the explicit frame operators. The length of the list
                 is the number of operators of the frame.
+            shape: TODO.
 
 
         Raises:
@@ -63,6 +66,8 @@ class MultiQubitFrame(BaseFrame[int]):
         self._pauli_operators: list[dict[str, complex]] | None
         self._array: np.ndarray
         self._informationally_complete: bool
+
+        self._shape = shape
 
         self.operators = list_operators
 

--- a/povm_toolbox/quantum_info/multi_qubit_povm.py
+++ b/povm_toolbox/quantum_info/multi_qubit_povm.py
@@ -16,12 +16,12 @@ import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
-from .base import BasePOVM
+from .base import BasePOVM, LabelT
 from .multi_qubit_dual import MultiQubitDual
 from .multi_qubit_frame import MultiQubitFrame
 
 
-class MultiQubitPOVM(MultiQubitFrame, BasePOVM):
+class MultiQubitPOVM(MultiQubitFrame[LabelT], BasePOVM):
     """Class that collects all information that any POVM over multiple qubits should specify.
 
     This is a representation of a positive operator-valued measure (POVM). The effects are
@@ -55,13 +55,13 @@ class MultiQubitPOVM(MultiQubitFrame, BasePOVM):
         """
         summed_op: np.ndarray = np.zeros((self.dimension, self.dimension), dtype=complex)
 
-        for k, op in enumerate(self.operators):
+        for key, op in self.operators.items():
             if not np.allclose(op, op.adjoint(), atol=1e-5):
-                raise ValueError(f"POVM operator {k} is not hermitian.")
+                raise ValueError(f'POVM operator "{key}" is not hermitian.')
 
             for eigval in np.linalg.eigvalsh(op.data):
                 if eigval.real < -1e-6 or np.abs(eigval.imag) > 1e-5:
-                    raise ValueError(f"Negative eigenvalue {eigval} in POVM operator {k}.")
+                    raise ValueError(f'Negative eigenvalue {eigval} in POVM operator "{key}".')
 
             summed_op += op.data
 

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -252,6 +252,10 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
                     local_idx = frame_op_idx[j]
                     coeff = povm.pauli_operators[local_idx][sublabel]
                 except KeyError:
+                    try:
+                        _ = povm.pauli_operators[local_idx]
+                    except KeyError as err:
+                        raise err
                     # If it does not exist, the current summand becomes 0 because it would be
                     # multiplied by 0.
                     summand = 0.0

--- a/povm_toolbox/quantum_info/single_qubit_povm.py
+++ b/povm_toolbox/quantum_info/single_qubit_povm.py
@@ -22,7 +22,7 @@ from qiskit.visualization.utils import matplotlib_close_if_inline
 from .multi_qubit_povm import MultiQubitPOVM
 
 
-class SingleQubitPOVM(MultiQubitPOVM):
+class SingleQubitPOVM(MultiQubitPOVM[int]):
     """A convenience class to represent a single-qubit :class:`.MultiQubitPOVM` instance.
 
     Below is a simple example showing how you define a symmetric and informationally-complete POVM
@@ -100,13 +100,13 @@ class SingleQubitPOVM(MultiQubitPOVM):
             ValueError: if any effect of this POVM has a rank greater than 1.
         """
         r = np.empty((self.num_outcomes, 3))
-        for i, pauli_op in enumerate(self.pauli_operators):
+        for i, (key, pauli_op) in enumerate(self.pauli_operators.items()):
             # Check that the povm effect is rank-1:
-            if np.linalg.matrix_rank(self.operators[i]) > 1:
+            if np.linalg.matrix_rank(self.operators[key]) > 1:
                 raise ValueError(
                     "Bloch vector is only well-defined for single-qubit rank-1"
                     f" POVMs. However, the effect number {i} of this POVM has"
-                    f" rank {np.linalg.matrix_rank(self.operators[i])}."
+                    f" rank {np.linalg.matrix_rank(self.operators[key])}."
                 )
             r[i, 0] = 2 * np.real_if_close(pauli_op.get("X", 0))
             r[i, 1] = 2 * np.real_if_close(pauli_op.get("Y", 0))

--- a/test/library/test_dilation_measurements.py
+++ b/test/library/test_dilation_measurements.py
@@ -146,7 +146,7 @@ class TestDilationMeasurements(TestCase):
                     [-0.11785113 - 2.04124140e-01j, 0.33333331 - 6.84480542e-18j],
                 ]
             )
-            for effect, povm_operator in zip(effects, povm.operators):
+            for effect, povm_operator in zip(effects, povm.operators.values()):
                 self.assertTrue(np.allclose(povm_operator.data, effect))
 
         with self.subTest("Test bloch vectors"):

--- a/test/quantum_info/test_multi_qubit_povm.py
+++ b/test/quantum_info/test_multi_qubit_povm.py
@@ -63,12 +63,12 @@ class TestMultiQubitPOVM(TestCase):
             [Operator(2 * i / (n * (n + 1)) * np.eye(4)) for i in range(1, n + 1)]
         )
         self.assertIsInstance(povm[2], Operator)
-        self.assertIsInstance(povm[1:2], list)
-        self.assertIsInstance(povm[:2], list)
+        # self.assertIsInstance(povm[1:2], list)
+        # self.assertIsInstance(povm[:2], list)
         self.assertEqual(povm[0], povm.operators[0])
-        self.assertListEqual(povm[3:], [povm.operators[3], povm.operators[4], povm.operators[5]])
-        self.assertListEqual(povm[::2], [povm.operators[0], povm.operators[2], povm.operators[4]])
-        self.assertListEqual(povm[2::-1], [povm.operators[2], povm.operators[1], povm.operators[0]])
+        # self.assertListEqual(povm[3:], [povm.operators[3], povm.operators[4], povm.operators[5]])
+        # self.assertListEqual(povm[::2], [povm.operators[0], povm.operators[2], povm.operators[4]])
+        # self.assertListEqual(povm[2::-1], [povm.operators[2], povm.operators[1], povm.operators[0]])
 
     def test_informationally_complete(self):
         """Test whether a POVM is informationally complete or not."""
@@ -138,10 +138,10 @@ class TestMultiQubitPOVM(TestCase):
         """Test the ``__repr__`` method."""
         povm = MultiQubitPOVM([Operator.from_label("0"), Operator.from_label("1")])
         with self.subTest("Non-square operators") and self.assertRaises(ValueError):
-            povm.operators = [
-                Operator(np.array([[1, 0, 0], [0, 0, 0]])),
-                Operator(np.array([[0, 0, 0], [0, 1, 0]])),
-            ]
+            povm.operators = {
+                0: Operator(np.array([[1, 0, 0], [0, 0, 0]])),
+                1: Operator(np.array([[0, 0, 0], [0, 1, 0]])),
+            }
 
     def test_pauli_operators(self):
         """Test errors are raised  correctly for the ``pauli_operators`` attribute."""
@@ -167,7 +167,7 @@ class TestMultiQubitPOVM(TestCase):
             frame_coefficients = povm.analysis(operator)
             self.assertIsInstance(frame_coefficients, np.ndarray)
             self.assertTrue(np.allclose(frame_coefficients, np.array([0.8, 0.2])))
-        with self.subTest("Invalid type for ``frame_op_idx``.") and self.assertRaises(TypeError):
+        with self.subTest("Invalid type for ``frame_op_idx``.") and self.assertRaises(KeyError):
             _ = povm.analysis(operator, (0, 1))
 
     def test_draw_bloch(self):

--- a/test/quantum_info/test_product_povm.py
+++ b/test/quantum_info/test_product_povm.py
@@ -51,16 +51,16 @@ class TestProductPOVM(TestCase):
                     -1, 1, (6, 2, 2)
                 )
             # artificially make the 2nd povm invalid and bypass the private `check_validity` method
-            mq_povm2._operators = [Operator(op) for op in ops]
+            mq_povm2._operators = {i: Operator(op) for i, op in enumerate(ops)}
             _ = ProductPOVM({(0,): mq_povm1, (1,): mq_povm2})
         with self.subTest("Operators with negative eigenvalues") and self.assertRaises(ValueError):
             op = np.array([[-0.5, 0], [0, 0]])
             # artificially make the 2nd povm invalid and bypass the private `check_validity` method
-            mq_povm2._operators = [Operator(op), Operator(np.eye(2) - op)]
+            mq_povm2._operators = {0: Operator(op), 1: Operator(np.eye(2) - op)}
             _ = ProductPOVM({(0,): mq_povm1, (1,): mq_povm2})
         with self.subTest("Operators not summing up to identity") and self.assertRaises(ValueError):
             # artificially make the 2nd povm invalid and bypass the private `check_validity` method
-            mq_povm2._operators = [0.9 * Operator.from_label("0"), Operator.from_label("1")]
+            mq_povm2._operators = {0: 0.9 * Operator.from_label("0"), 1: Operator.from_label("1")}
             _ = ProductPOVM({(0,): mq_povm1, (1,): mq_povm2})
 
     def test_init(self):
@@ -328,11 +328,11 @@ class TestProductPOVM(TestCase):
             _ = prod_povm.analysis(observable, frame_op_idx=(0, 0))
         with self.subTest(
             "Test invalid ``frame_op_idx`` argument (out of range)."
-        ) and self.assertRaises(IndexError):
+        ) and self.assertRaises(KeyError):
             observable = Operator.from_label("ZZZ")
             _ = prod_povm.analysis(observable, frame_op_idx=(0, 0, 6))
         with self.subTest(
             "Test invalid ``frame_op_idx`` argument (negative out of range)."
-        ) and self.assertRaises(IndexError):
+        ) and self.assertRaises(KeyError):
             observable = Operator.from_label("ZZZ")
             _ = prod_povm.analysis(observable, frame_op_idx=(0, 0, -10))

--- a/test/quantum_info/test_single_qubit_povm.py
+++ b/test/quantum_info/test_single_qubit_povm.py
@@ -42,7 +42,7 @@ class TestSingleQubitPovm(TestCase):
         sqpovm = SingleQubitPOVM.from_vectors(V)
 
         summed = defaultdict(complex)
-        for pauli_op in sqpovm.pauli_operators:
+        for pauli_op in sqpovm.pauli_operators.values():
             for pauli, coeff in pauli_op.items():
                 summed[pauli] += coeff
 


### PR DESCRIPTION
The idea is to relax the indexing of the operators (or outcomes) for a mutli-qubit frame/povm/dual.
Currently, they are indexed by integers (which came from the fact that they are stored in a list). We could reshape (maybe virtually) that list and index operators by `tuple[int, ...]`. We could go further and store the operators in a `dict` and key could even be strings for instance.