### PR TITLE
Set default `dpi` for figure of `draw_bloch` method

### DIFF
--- a/povm_toolbox/quantum_info/product_povm.py
+++ b/povm_toolbox/quantum_info/product_povm.py
@@ -139,6 +139,7 @@ class ProductPOVM(ProductFrame[MultiQubitPOVM], BasePOVM):
                 colorbar=colorbar,
             )
         fig.suptitle(title, fontsize=title_font_size, y=1.0)
+        fig.dpi = 100.0
         matplotlib_close_if_inline(fig)
 
         return fig

--- a/povm_toolbox/quantum_info/single_qubit_povm.py
+++ b/povm_toolbox/quantum_info/single_qubit_povm.py
@@ -180,6 +180,7 @@ class SingleQubitPOVM(MultiQubitPOVM):
             figure = B.fig
             axes = B.axes
             figure.set_size_inches(figsize[0], figsize[1])
+            figure.dpi = 100.0
             matplotlib_close_if_inline(figure)
 
         if colorbar:


### PR DESCRIPTION
The doctests were sometimes failing because the `dpi` (hence the output) would change from a machine to another.