### PR TITLE
Feat: add a method to easily access the state "snapshots"

### DIFF
--- a/povm_toolbox/post_processor/povm_post_processor.py
+++ b/povm_toolbox/post_processor/povm_post_processor.py
@@ -16,8 +16,9 @@ import logging
 from typing import Any, cast
 
 import numpy as np
-from qiskit.quantum_info import SparsePauliOp
+from qiskit.quantum_info import Operator, SparsePauliOp
 
+from povm_toolbox.quantum_info import ProductDual
 from povm_toolbox.quantum_info.base import BaseDual, BasePOVM
 from povm_toolbox.sampler import POVMPubResult
 
@@ -220,3 +221,23 @@ class POVMPostProcessor:
             std = float("NaN")
 
         return exp_val, std
+
+    def get_state_snapshot(self, outcome: tuple[int, ...]) -> dict[tuple[int, ...], Operator]:
+        """Return the snapshot of the state associated with `outcome`.
+
+        Args:
+            outcome: the label specifying the snapshot. The outcome is a tuple of integers (one
+                index per local frame).
+
+        Returns:
+            The snapshot associated with `outcome`. The snapshot is a product operator, which is
+            returned as a dictionary mapping the subsystems of the Hilbert space (e.g. qubits) to
+            the corresponding local operators forming the product operator.
+
+        Raises:
+            NotImplementedError: if the dual frame associated with the post-processor is not
+                product.
+        """
+        if isinstance(self.dual, ProductDual):
+            return self.dual.get_operator(outcome)
+        raise NotImplementedError("This method is only implemented for `ProductDual` objects.")

--- a/povm_toolbox/post_processor/povm_post_processor.py
+++ b/povm_toolbox/post_processor/povm_post_processor.py
@@ -223,14 +223,14 @@ class POVMPostProcessor:
         return exp_val, std
 
     def get_state_snapshot(self, outcome: tuple[int, ...]) -> dict[tuple[int, ...], Operator]:
-        """Return the snapshot of the state associated with `outcome`.
+        """Return the snapshot of the state associated with ``outcome``.
 
         Args:
             outcome: the label specifying the snapshot. The outcome is a tuple of integers (one
                 index per local frame).
 
         Returns:
-            The snapshot associated with `outcome`. The snapshot is a product operator, which is
+            The snapshot associated with ``outcome``. The snapshot is a product operator, which is
             returned as a dictionary mapping the subsystems of the Hilbert space (e.g. qubits) to
             the corresponding local operators forming the product operator.
 

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -224,7 +224,7 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
                 labeled by a tuple of integers (one index per local frame).
 
         Returns:
-            The product frame operator specified by `frame_op_idx`. The operator is returned in a
+            The product frame operator specified by ``frame_op_idx``. The operator is returned in a
             product form. More specifically, is it a dictionary mapping the subsystems to the
             corresponding local frame operators forming the product frame operator.
         """

--- a/povm_toolbox/quantum_info/product_frame.py
+++ b/povm_toolbox/quantum_info/product_frame.py
@@ -216,6 +216,23 @@ class ProductFrame(BaseFrame[tuple[int, ...]], Generic[T]):
         """Return the number of outcomes of the product frame."""
         return self.num_operators
 
+    def get_operator(self, frame_op_idx: tuple[int, ...]) -> dict[tuple[int, ...], Operator]:
+        """Return a product frame operator in a product form.
+
+        Args:
+            frame_op_idx: the label specifying the frame operator to get. The frame operator is
+                labeled by a tuple of integers (one index per local frame).
+
+        Returns:
+            The product frame operator specified by `frame_op_idx`. The operator is returned in a
+            product form. More specifically, is it a dictionary mapping the subsystems to the
+            corresponding local frame operators forming the product frame operator.
+        """
+        product_operator = {}
+        for local_idx, (subsystem, povm) in zip(frame_op_idx, self._frames.items()):
+            product_operator[subsystem] = povm.operators[local_idx]
+        return product_operator
+
     def _trace_of_prod(self, operator: SparsePauliOp, frame_op_idx: tuple[int, ...]) -> float:
         """Return the trace of the product of a Hermitian operator with a specific frame operator.
 

--- a/releasenotes/notes/add-get-snapshot-method-ee4f85a7b06cb373.yaml
+++ b/releasenotes/notes/add-get-snapshot-method-ee4f85a7b06cb373.yaml
@@ -1,7 +1,10 @@
 ---
 features:
   - |
-    Add a method to easily access the classical "snapshots" of the state after taking some
-    measurements. A classical "snapshot" of the state is the dual frame operator associated with the
-    corresponding outcome. The new method returns the snapshot (typically as a product of local
-    operators) associated with the queried outcome (typically a tuple of integers).
+    A new method, :meth:`.POVMPostProcessor.get_state_snapshot`, is implemented to easily access the
+    classical "snapshots" of the state after taking some measurements. A classical "snapshot" of the
+    state is the dual frame operator associated with the corresponding outcome. The new method
+    returns the snapshot (typically as a product of local operators) associated with the queried
+    outcome (typically a tuple of integers).
+    In parallel, the :meth:`.ProductFrame.get_operator` method has been added for more general
+    access to frame operators in a product form.

--- a/releasenotes/notes/add-get-snapshot-method-ee4f85a7b06cb373.yaml
+++ b/releasenotes/notes/add-get-snapshot-method-ee4f85a7b06cb373.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add a method to easily access the classical "snapshots" of the state after taking some
+    measurements. A classical "snapshot" of the state is the dual frame operator associated with the
+    corresponding outcome. The new method returns the snapshot (typically as a product of local
+    operators) associated with the queried outcome (typically a tuple of integers).

--- a/test/quantum_info/test_product_frame.py
+++ b/test/quantum_info/test_product_frame.py
@@ -66,3 +66,24 @@ class TestProductFrame(TestCase):
             check = np.ones(len(product_paulis)) * 2**num_qubit
             self.assertTrue(np.allclose(decomposition_weights_n_qubit, check))
             self.assertTrue(np.allclose(decomposition_weights_product, check))
+
+    def test_get_operator(self):
+        """Test that the ``get_operator`` method works correctly."""
+        frame_0 = MultiQubitFrame([Operator.from_label(label) for label in ["I", "X", "Y", "Z"]])
+        frame_1 = MultiQubitFrame([Operator.from_label(label) for label in ["0", "1"]])
+        frame_product = ProductFrame.from_list(frames=[frame_0, frame_1])
+
+        with self.subTest("Test method works correctly"):
+            frame_op_idx = (0, 1)
+            expected_snapshot = {(0,): Operator.from_label("I"), (1,): Operator.from_label("1")}
+            snapshot = frame_product.get_operator(frame_op_idx)
+            self.assertDictEqual(snapshot, expected_snapshot)
+
+            frame_op_idx = (2, 0)
+            expected_snapshot = {(0,): Operator.from_label("Y"), (1,): Operator.from_label("0")}
+            snapshot = frame_product.get_operator(frame_op_idx)
+            self.assertDictEqual(snapshot, expected_snapshot)
+
+        with self.subTest("invalid frame_op_idx") and self.assertRaises(IndexError):
+            frame_op_idx = (10, 20)
+            frame_product.get_operator(frame_op_idx)


### PR DESCRIPTION
The classical "snapshots" of the state are simply the dual frame operators. Add an easy way of accessing the snapshot (typically an operator in a product form) associated with a given outcome (typically a tuple of integers).