### PR TITLE
Introduce a optional virtual shape for MultiQubitFrame objects

### DIFF
--- a/test/quantum_info/test_multi_qubit_povm.py
+++ b/test/quantum_info/test_multi_qubit_povm.py
@@ -167,7 +167,7 @@ class TestMultiQubitPOVM(TestCase):
             frame_coefficients = povm.analysis(operator)
             self.assertIsInstance(frame_coefficients, np.ndarray)
             self.assertTrue(np.allclose(frame_coefficients, np.array([0.8, 0.2])))
-        with self.subTest("Invalid type for ``frame_op_idx``.") and self.assertRaises(TypeError):
+        with self.subTest("Invalid type for ``frame_op_idx``.") and self.assertRaises(ValueError):
             _ = povm.analysis(operator, (0, 1))
 
     def test_draw_bloch(self):


### PR DESCRIPTION
The idea is to relax the indexing of the operators (or outcomes) for a mutli-qubit frame/povm/dual.
Currently, they are indexed by integers (which comes from the fact that they are stored in a list). We want to be able to reshape (virtually) that list and index operators by tuple[int, ...]. 

In #97, we thought of going further by storing the operators in a dict. Hence the key could even be strings for instance. This proved to cumbersome, therefore we are closing #97 without merging it.