### PR TITLE
fix: properly skip action secret-dependent test

### DIFF
--- a/test/sampler/test_povm_sampler_job.py
+++ b/test/sampler/test_povm_sampler_job.py
@@ -157,7 +157,7 @@ class TestPOVMSamplerJob(TestCase):
                 Path(filename).unlink(missing_ok=True)
 
     @pytest.mark.skipif(
-        os.getenv("QISKIT_IBM_TOKEN") is None, reason="Missing QiskitRuntimeService configuration."
+        not os.getenv("QISKIT_IBM_TOKEN"), reason="Missing QiskitRuntimeService configuration."
     )
     def test_recover_job_runtime(self):
         qc = QuantumCircuit(2)


### PR DESCRIPTION
The Github action secrets are not available for branches running on forks or for PRs coming from forks or non-collaborator contributors (such as dependendabot or mergify). Therefore, we must skip tests depending on such secrets.

This was attempted in the past, but the check only worked when the environment variable was actually `None`, not when it was an empty string. This commit addresses that.