### PR TITLE
Update intersphinx mapping and other URLs pointing to IQP Classic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,8 +102,8 @@ modindex_common_prefix = ["povm_toolbox."]
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
-    "qiskit_ibm_runtime": ("https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
+    "qiskit_ibm_runtime": ("https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/", None),
     "rustworkx": ("https://www.rustworkx.org/", None),
 }
 

--- a/povm_toolbox/sampler/__init__.py
+++ b/povm_toolbox/sampler/__init__.py
@@ -14,7 +14,7 @@
 
 At their core, POVMs are used in combination with sampling the state of a quantum circuit.
 In Qiskit, this functionality is provided via the
-`Sampler primitive <https://docs.quantum.ibm.com/guides/primitives>`_.
+`Sampler primitive <https://quantum.cloud.ibm.com/docs/guides/primitives>`_.
 
 To this end, this module provides a number of tools for sampling the state of
 :class:`~qiskit.circuit.QuantumCircuit` objects using a :class:`.POVMImplementation`.


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.