### PR TITLE
ci: enforce 100% unittest coverage

### DIFF
--- a/povm_toolbox/quantum_info/product_povm.py
+++ b/povm_toolbox/quantum_info/product_povm.py
@@ -103,7 +103,7 @@ class ProductPOVM(ProductFrame[MultiQubitPOVM], BasePOVM):
 
         # Check that all local POVMs are single-qubit POVMs
         if any([len(idx) > 1 for idx in self.sub_systems]):
-            raise NotImplementedError
+            raise NotImplementedError  # pragma: no cover
 
         # Determine the number of rows and columns for the figure
         n_cols = int(np.sqrt(num) * 4 / 3)
@@ -112,10 +112,10 @@ class ProductPOVM(ProductFrame[MultiQubitPOVM], BasePOVM):
             n_cols += 1 if n_cols * n_rows < num else 0
             n_rows += 1 if n_cols * n_rows < num else 0
             while (n_cols - 1) * n_rows >= num:
-                n_cols -= 1
+                n_cols -= 1  # pragma: no cover
 
         # Set default values
-        if figsize is None:
+        if figsize is None:  # pragma: no branch
             figsize = (5, 4) if colorbar else (5, 5)
         width, height = figsize
         width *= n_cols

--- a/povm_toolbox/quantum_info/single_qubit_povm.py
+++ b/povm_toolbox/quantum_info/single_qubit_povm.py
@@ -168,11 +168,11 @@ class SingleQubitPOVM(MultiQubitPOVM):
 
         if colorbar:
             # Keep track of vector norms through colorbar
-            cmap = mpl.colormaps["viridis"]
-            B.vector_color = [cmap(np.linalg.norm(vec)) for vec in vectors]
+            cmap = mpl.colormaps["viridis"]  # pragma: no cover
+            B.vector_color = [cmap(np.linalg.norm(vec)) for vec in vectors]  # pragma: no cover
             # Normalize
-            for i in range(len(vectors)):
-                vectors[i] /= np.linalg.norm(vectors[i])
+            for i in range(len(vectors)):  # pragma: no cover
+                vectors[i] /= np.linalg.norm(vectors[i])  # pragma: no cover
 
         B.add_vectors(vectors)
         B.render(title=title)
@@ -185,6 +185,8 @@ class SingleQubitPOVM(MultiQubitPOVM):
             matplotlib_close_if_inline(figure)
 
         if colorbar:
-            figure.colorbar(mpl.cm.ScalarMappable(cmap=cmap), ax=axes, label="weight")
+            figure.colorbar(  # pragma: no cover
+                mpl.cm.ScalarMappable(cmap=cmap), ax=axes, label="weight"
+            )
 
         return figure

--- a/povm_toolbox/sampler/povm_sampler_job.py
+++ b/povm_toolbox/sampler/povm_sampler_job.py
@@ -175,6 +175,10 @@ class POVMSamplerJob(BasePrimitiveJob[POVMPubResult, JobStatus]):
                 service = QiskitRuntimeService()  # pragma: no cover
             # Load the ``BasePrimitiveJob`` object:
             base_job = service.job(job_id)
+            # NOTE: if your local coverage test failed because the above line is not covered, that
+            # is to be expected because your local development environment likely does not have the
+            # right authentications saved to run the corresponding test. This is covered in CI, so
+            # if that passes, all is good.
         elif base_job.job_id() != job_id:
             raise ValueError(
                 f"The ID of the supplied job ({base_job.job_id()}) does not match the ID stored in "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.23",
     "numba>=0.59",
-    "qiskit>=2.0, <3",
+    "qiskit>=1.4, <3",
     "qiskit-ibm-runtime>=0.24",
     "matplotlib!=3.9.1.post1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.23",
     "numba>=0.59",
-    "qiskit>=1.4, <3",
+    "qiskit>=2.0, <3",
     "qiskit-ibm-runtime>=0.24",
     "matplotlib!=3.9.1.post1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ branch = true
 parallel = true
 
 [tool.coverage.report]
-fail_under = 95
+fail_under = 100
 show_missing = true
 
 [tool.hatch.build.targets.wheel]

--- a/test/library/test_dilation_measurements.py
+++ b/test/library/test_dilation_measurements.py
@@ -59,9 +59,9 @@ class TestDilationMeasurements:
     @pytest.mark.parametrize(
         ["pauli", "expected_exp_val", "expected_std"],
         [
-            ("ZI", -0.18749595202757485, 0.1428020261876306),
-            ("IZ", -0.18749696469140917, 0.14280207155875035),
-            ("XI", 0.8949297904387811, 0.16958103337866423),
+            ("ZI", -0.18749696469140853, 0.1428020715587502),
+            ("IZ", -0.18750068585105134, 0.1428022382724095),
+            ("XI", 0.8949297904387798, 0.16958103337866398),
         ],
     )
     def test_to_sampler_pub(self, pauli: str, expected_exp_val: float, expected_std: float):
@@ -76,7 +76,10 @@ class TestDilationMeasurements:
         )
 
         pm = generate_preset_pass_manager(
-            optimization_level=2, backend=backend, seed_transpiler=self.SEED
+            optimization_level=0,
+            initial_layout=[0, 1, 2, 3],
+            backend=backend,
+            seed_transpiler=self.SEED,
         )
 
         measurement = DilationMeasurements(

--- a/test/library/test_randomized_projective_measurements.py
+++ b/test/library/test_randomized_projective_measurements.py
@@ -14,7 +14,6 @@ from collections import Counter
 
 import numpy as np
 import pytest
-import qiskit
 from numpy.random import default_rng
 from povm_toolbox.library import ClassicalShadows, RandomizedProjectiveMeasurements
 from povm_toolbox.library.metadata import POVMMetadata
@@ -152,11 +151,15 @@ class TestRandomizedPMs:
 
             assert qc.num_qubits == num_qubits
 
-    @pytest.mark.skipif(
-        not qiskit.__version__.startswith("1"),
-        reason="https://github.com/qiskit-community/povm-toolbox/issues/109",
+    @pytest.mark.parametrize(
+        ["pauli", "expected_exp_val", "expected_std"],
+        [
+            ("ZI", 1.0156250000000002, 0.1785027593993689),
+            ("IZ", 0.1171875000000002, 0.17940912620515942),
+            ("XI", 0.04822534966686553, 0.2793620349223184),
+        ],
     )
-    def test_to_sampler_pub(self):
+    def test_to_sampler_pub(self, pauli: str, expected_exp_val: float, expected_std: float):
         """Test that the ``to_sampler_pub`` method works correctly."""
         num_qubits = 2
         qc = QuantumCircuit(2)
@@ -167,7 +170,12 @@ class TestRandomizedPMs:
             sampler=Sampler(backend=backend, options={"seed_simulator": self.SEED})
         )
 
-        pm = generate_preset_pass_manager(optimization_level=2, backend=backend)
+        pm = generate_preset_pass_manager(
+            optimization_level=0,
+            initial_layout=[0, 1],
+            backend=backend,
+            seed_transpiler=self.SEED,
+        )
 
         measurement = RandomizedProjectiveMeasurements(
             num_qubits,
@@ -181,18 +189,10 @@ class TestRandomizedPMs:
 
         post_processor = POVMPostProcessor(pub_result)
 
-        observable = SparsePauliOp(["ZI"], coeffs=[1.0])
+        observable = SparsePauliOp([pauli], coeffs=[1.0])
         exp_value, std = post_processor.get_expectation_value(observable)
-        assert np.isclose(exp_value, 1.015624999999999)
-        assert np.isclose(std, 0.17850275939936872)
-        observable = SparsePauliOp(["IZ"], coeffs=[1.0])
-        exp_value, std = post_processor.get_expectation_value(observable)
-        assert np.isclose(exp_value, 0.8203124999999986)
-        assert np.isclose(std, 0.16430837874418103)
-        observable = SparsePauliOp(["XI"], coeffs=[1.0])
-        exp_value, std = post_processor.get_expectation_value(observable)
-        assert np.isclose(exp_value, 0.48385279322581587)
-        assert np.isclose(std, 0.27607615877584807)
+        assert np.isclose(exp_value, expected_exp_val)
+        assert np.isclose(std, expected_std)
 
     def test_binding_parameters(self):
         num_qubits = 2

--- a/test/library/test_randomized_projective_measurements.py
+++ b/test/library/test_randomized_projective_measurements.py
@@ -156,6 +156,12 @@ class TestRandomizedPMs:
         ["pauli", "expected_exp_val", "expected_std"],
         [
             ("ZI", 1.0156250000000002, 0.1785027593993689),
+            # NOTE: the seemingly random differentiation based on the Qiskit version below are a
+            # simple artifact of a change in simulator seed handling. This results in vastly
+            # different samples being generated for this circuit which in turn results in vastly
+            # different expectation values (since we have a very small number of shots to being
+            # with). It is a pure coincidence that this only shows up for the following two test
+            # cases and not anywhere else.
             (
                 "IZ",
                 0.1171875000000002 if qiskit.__version__.startswith("2") else 0.8203125000000001,

--- a/test/library/test_randomized_projective_measurements.py
+++ b/test/library/test_randomized_projective_measurements.py
@@ -159,12 +159,12 @@ class TestRandomizedPMs:
             (
                 "IZ",
                 0.1171875000000002 if qiskit.__version__.startswith("2") else 0.8203125000000001,
-                0.17940912620515942,
+                0.17940912620515942 if qiskit.__version__.startswith("2") else 0.16430837874418136,
             ),
             (
                 "XI",
                 0.04822534966686553 if qiskit.__version__.startswith("2") else 0.48385279322581426,
-                0.2793620349223184,
+                0.2793620349223184 if qiskit.__version__.startswith("2") else 0.27607615877584846,
             ),
         ],
     )

--- a/test/library/test_randomized_projective_measurements.py
+++ b/test/library/test_randomized_projective_measurements.py
@@ -14,6 +14,7 @@ from collections import Counter
 
 import numpy as np
 import pytest
+import qiskit
 from numpy.random import default_rng
 from povm_toolbox.library import ClassicalShadows, RandomizedProjectiveMeasurements
 from povm_toolbox.library.metadata import POVMMetadata
@@ -155,8 +156,16 @@ class TestRandomizedPMs:
         ["pauli", "expected_exp_val", "expected_std"],
         [
             ("ZI", 1.0156250000000002, 0.1785027593993689),
-            ("IZ", 0.1171875000000002, 0.17940912620515942),
-            ("XI", 0.04822534966686553, 0.2793620349223184),
+            (
+                "IZ",
+                0.1171875000000002 if qiskit.__version__.startswith("2") else 0.8203125000000001,
+                0.17940912620515942,
+            ),
+            (
+                "XI",
+                0.04822534966686553 if qiskit.__version__.startswith("2") else 0.48385279322581426,
+                0.2793620349223184,
+            ),
         ],
     )
     def test_to_sampler_pub(self, pauli: str, expected_exp_val: float, expected_std: float):

--- a/test/sampler/test_povm_sampler_job.py
+++ b/test/sampler/test_povm_sampler_job.py
@@ -96,7 +96,10 @@ class TestPOVMSamplerJob:
         backend = FakeManilaV2()
         backend.set_options(seed_simulator=self.SEED)
         pm = generate_preset_pass_manager(
-            optimization_level=2, backend=backend, seed_transpiler=self.SEED
+            optimization_level=0,
+            initial_layout=[0, 1],
+            backend=backend,
+            seed_transpiler=self.SEED,
         )
 
         qc_isa = pm.run(qc)
@@ -174,7 +177,10 @@ class TestPOVMSamplerJob:
 
         backend = service.backend(name=qpu)
         pm = generate_preset_pass_manager(
-            optimization_level=2, backend=backend, seed_transpiler=self.SEED
+            optimization_level=0,
+            initial_layout=[0, 1],
+            backend=backend,
+            seed_transpiler=self.SEED,
         )
 
         qc_isa = pm.run(qc)


### PR DESCRIPTION
This enforces 100% unittest coverage in CI.

- lines not covered in the visualization functions of the Bloch spheres are exempted
- a note for developers is added for the line that will miss coverage in local runs
- the use of `generate_preset_pass_manager` is updated to (hopefully) guard against changes across major Qiskit versions (which fixes #109)