### PR TITLE
ci: use Agg matplotlib backend to avoid tkinter issues

### DIFF
--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Test using tox environment
         shell: bash
         env:
+          MPLBACKEND: Agg
           QISKIT_IBM_QPU: ${{ secrets.QISKIT_IBM_QPU }}
           QISKIT_IBM_TOKEN: ${{ secrets.QISKIT_IBM_TOKEN }}
           QISKIT_IBM_CHANNEL: ${{ secrets.QISKIT_IBM_CHANNEL }}

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ extras =
 commands =
   pytest {posargs}
 passenv =
+  MPLBACKEND
   QISKIT_IBM_QPU
   QISKIT_IBM_TOKEN
   QISKIT_IBM_CHANNEL


### PR DESCRIPTION
The flaky Windows CI test failures are caused by the Tcl/Tkinter backend not being found consistently. This is due to convoluted Python environment behavior on Windows and its interaction with the Tcl/Tkinter installed on the system level.

One way to fix that, would be to export the correct Tcl/Tkinter library path, but determining that is less straight forward than simply using an alternative matplotlib backend like `Agg` (which is non interactive, but that does not matter to us in this context).

Hopefully this stabilizes the Windows CI behavior while still passing all tests as expected.